### PR TITLE
Release: update publisher ID to advancer-limited

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A rich Markdown editor with live preview, wikilinks, backlink panel, graph visualizer, and LanguageTool grammar checking",
   "version": "0.1.0",
   "license": "MIT",
-  "publisher": "advancer",
+  "publisher": "advancer-limited",
   "repository": {
     "type": "git",
     "url": "https://github.com/Advancer-Limited/vscode-md-editor.git"


### PR DESCRIPTION
## Summary
- Merge publisher ID fix from develop to master for marketplace publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)