### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [0.2.1] - 2026-06-16
+
+### Fixed
+
+- Prevent cursor jump in WYSIWYG mode during editing (#24).
+
 ## [0.2.0] - 2026-03-13
 
 ### Added

--- a/log.md
+++ b/log.md
@@ -320,3 +320,11 @@ Uses a line-level LCS diff algorithm with no external dependencies.
 **Impact**: Zero changes to `markdownEditorProvider.ts` or any existing editor/wikilink/graph/grammar code. All diff code is in new isolated files.
 
 - Full build: `npm run compile` passes clean
+
+## 2026-06-16 — Release 0.2.1 to VS Code Marketplace
+
+- Marketplace already had 0.2.0; master/develop contained unpublished fix #24 (cursor jump in WYSIWYG) still tagged 0.2.0.
+- Bumped version 0.2.0 → 0.2.1 (patch) on branch `fix/bump-0.2.1` off `develop`.
+- Modified: `package.json`, `package-lock.json` (version), `CHANGELOG.md` (0.2.1 entry).
+- Flow: PR fix/bump-0.2.1 → develop, then develop → master, then publish from master.
+- `npm run check-types` passes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "publisher": "advancer-limited",
   "icon": "media/icon.png",

--- a/todo.md
+++ b/todo.md
@@ -105,3 +105,11 @@
 - [x] Create `CHANGELOG.md`
 - [x] Full build passes (`npm run compile`)
 - [x] Tested: rendered markdown diff with green/red highlights
+
+## Release 0.2.1
+
+- [x] Bump version to 0.2.1 (package.json, package-lock.json)
+- [x] Add CHANGELOG 0.2.1 entry
+- [ ] PR fix/bump-0.2.1 → develop, self-review, merge
+- [ ] PR develop → master, merge
+- [ ] Publish 0.2.1 from master to VS Code Marketplace


### PR DESCRIPTION
## Summary

Release 0.2.1 to master for VS Code Marketplace publication.

Patch bump publishing the WYSIWYG cursor-jump fix (#24) that landed after the 0.2.0 release.

## Changes since 0.2.0

- Fix: prevent cursor jump in WYSIWYG mode during editing (#24)
- chore: bump version 0.2.0 → 0.2.1 (#26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)