### PR TITLE
docs: correct marketplace PAT vault to kv-advancer-prod

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,9 @@ Use `gh pr review <number> --comment --body "..."` to add general comments, or `
 
 - VS Code Marketplace publisher name: `advancer-limited`
 - Publish with: `npx @vscode/vsce publish -p <PAT>`
-- PAT is stored in Azure Key Vault `kv-askance-prod` as `vsce-marketplace-pat`
-- The PAT must be created from the Azure DevOps account linked to the `advancer-limited` publisher
+- PAT is stored in Azure Key Vault `kv-advancer-prod` (Azure subscription `Advancer`) as `vsce-marketplace-pat`
+  - Fetch with: `az account set --subscription Advancer && az keyvault secret show --vault-name kv-advancer-prod --name vsce-marketplace-pat --query value -o tsv`
+- The PAT must be created from the Azure DevOps account linked to the `advancer-limited` publisher, with **All accessible organizations** + **Marketplace: Manage** scope
 
 ## Askance — Tool Call Oversight
 

--- a/log.md
+++ b/log.md
@@ -328,3 +328,10 @@ Uses a line-level LCS diff algorithm with no external dependencies.
 - Modified: `package.json`, `package-lock.json` (version), `CHANGELOG.md` (0.2.1 entry).
 - Flow: PR fix/bump-0.2.1 → develop, then develop → master, then publish from master.
 - `npm run check-types` passes.
+
+## 2026-06-16 — Published 0.2.1 + corrected vault docs
+
+- Published `advancer-limited.vscode-md-editor v0.2.1` to VS Code Marketplace from `master`.
+- Documented PAT location (`kv-askance-prod`) was wrong — that vault does not exist. Correct vault is `kv-advancer-prod` in the `Advancer` Azure subscription.
+- Created new PAT (All accessible orgs + Marketplace: Manage) and stored it as secret `vsce-marketplace-pat` in `kv-advancer-prod`.
+- Updated CLAUDE.md Publishing section with correct vault name and fetch command.

--- a/todo.md
+++ b/todo.md
@@ -112,4 +112,4 @@
 - [x] Add CHANGELOG 0.2.1 entry
 - [ ] PR fix/bump-0.2.1 → develop, self-review, merge
 - [ ] PR develop → master, merge
-- [ ] Publish 0.2.1 from master to VS Code Marketplace
+- [x] Publish 0.2.1 from master to VS Code Marketplace


### PR DESCRIPTION
## Summary

The Publishing section of CLAUDE.md pointed at Azure Key Vault `kv-askance-prod`, which does not exist. The marketplace PAT actually lives in `kv-advancer-prod` (Azure subscription `Advancer`).

## Changes

- `CLAUDE.md` — correct vault name, add `az` fetch command, document required PAT scopes (All accessible orgs + Marketplace: Manage)
- `log.md` / `todo.md` — record the 0.2.1 publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)