### PR TITLE
fix: preserve table formatting when editing in WYSIWYG mode

### DIFF
--- a/log.md
+++ b/log.md
@@ -335,3 +335,12 @@ Uses a line-level LCS diff algorithm with no external dependencies.
 - Documented PAT location (`kv-askance-prod`) was wrong — that vault does not exist. Correct vault is `kv-advancer-prod` in the `Advancer` Azure subscription.
 - Created new PAT (All accessible orgs + Marketplace: Manage) and stored it as secret `vsce-marketplace-pat` in `kv-advancer-prod`.
 - Updated CLAUDE.md Publishing section with correct vault name and fetch command.
+
+## 2026-06-16 — Fix: WYSIWYG table formatting lost on edit
+
+- Bug: editing inside a table in WYSIWYG (contenteditable) mode destroyed the markdown table.
+- Root cause: `media/editor.js` runs Turndown (HTML→markdown) on every input, but Turndown's core has NO table support, so `<table>` was flattened to plain concatenated cell text and saved as the source.
+- Fix: added self-contained GFM table rules to the TurndownService (tableCell, tableRow, tableSection, table) — adaptation of turndown-plugin-gfm, no new dependency.
+  - Preserves header separator row, column alignment (reads both `align` attr and `text-align` style, since markdown-it emits inline styles), inline cell formatting, and escapes literal pipes.
+  - Only tables with a heading row are converted (others left to default handling).
+- Verified with a markdown→html→markdown round-trip test (basic, aligned, inline, escaped-pipe cases all pass); `npm run compile` passes.

--- a/media/editor.js
+++ b/media/editor.js
@@ -77,6 +77,97 @@
     },
   });
 
+  // Custom rules: GFM tables. Turndown's core has NO table support — without
+  // these rules a <table> is flattened to plain concatenated cell text, so
+  // editing a table in WYSIWYG mode destroys its markdown formatting. This is a
+  // self-contained adaptation of turndown-plugin-gfm's table rules.
+
+  /** Render a single cell, prefixing the row's leading `|`. */
+  function tableCellMarkup(content, node) {
+    const index = Array.prototype.indexOf.call(node.parentNode.childNodes, node);
+    const prefix = index === 0 ? '| ' : ' ';
+    // Cells must be single-line, and literal pipes have to be escaped so they
+    // aren't read as column separators.
+    const cellText = content.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|').trim();
+    return prefix + cellText + ' |';
+  }
+
+  /** A <tbody> with no preceding content-bearing <thead> acts as the header. */
+  function isFirstTbody(element) {
+    const previousSibling = element.previousSibling;
+    return (
+      element.nodeName === 'TBODY' &&
+      (!previousSibling ||
+        (previousSibling.nodeName === 'THEAD' && /^\s*$/i.test(previousSibling.textContent)))
+    );
+  }
+
+  /** Is this <tr> the table's heading row (the one followed by `---` separators)? */
+  function isHeadingRow(tr) {
+    if (!tr) return false;
+    const parent = tr.parentNode;
+    return (
+      parent.nodeName === 'THEAD' ||
+      (parent.firstChild === tr &&
+        (parent.nodeName === 'TABLE' || isFirstTbody(parent)) &&
+        Array.prototype.every.call(tr.childNodes, function (n) {
+          return n.nodeName === 'TH';
+        }))
+    );
+  }
+
+  turndownService.addRule('tableCell', {
+    filter: ['th', 'td'],
+    replacement: function (content, node) {
+      return tableCellMarkup(content, node);
+    },
+  });
+
+  /** Column alignment, from the `align` attribute or `text-align` style. */
+  function cellAlignment(node) {
+    const attr = node.getAttribute && node.getAttribute('align');
+    const style = (node.style && node.style.textAlign) || '';
+    return (attr || style || '').toLowerCase();
+  }
+
+  turndownService.addRule('tableRow', {
+    filter: 'tr',
+    replacement: function (content, node) {
+      let borderCells = '';
+      const alignMap = { left: ':---', right: '---:', center: ':---:' };
+      if (isHeadingRow(node)) {
+        for (let i = 0; i < node.childNodes.length; i++) {
+          const child = node.childNodes[i];
+          let border = '---';
+          const align = cellAlignment(child);
+          if (align) border = alignMap[align] || border;
+          borderCells += tableCellMarkup(border, child);
+        }
+      }
+      return '\n' + content + (borderCells ? '\n' + borderCells : '');
+    },
+  });
+
+  turndownService.addRule('tableSection', {
+    filter: ['thead', 'tbody', 'tfoot'],
+    replacement: function (content) {
+      return content;
+    },
+  });
+
+  // Only tables with a heading row can be expressed as GFM markdown; others
+  // are left to Turndown's default handling.
+  turndownService.addRule('table', {
+    filter: function (node) {
+      return node.nodeName === 'TABLE' && isHeadingRow(node.rows[0]);
+    },
+    replacement: function (content) {
+      // Collapse the blank line Turndown inserts between the header row and the
+      // separator so the table stays contiguous.
+      return '\n\n' + content.replace(/\n+/g, '\n') + '\n\n';
+    },
+  });
+
   /** Check if the editor is in preview-only (WYSIWYG) mode */
   function isPreviewMode() {
     return editorContainer.classList.contains('preview-only');

--- a/todo.md
+++ b/todo.md
@@ -113,3 +113,4 @@
 - [ ] PR fix/bump-0.2.1 → develop, self-review, merge
 - [ ] PR develop → master, merge
 - [x] Publish 0.2.1 from master to VS Code Marketplace
+- [x] Fix WYSIWYG table formatting loss (Turndown GFM table rules)


### PR DESCRIPTION
## Summary

Editing inside a table in WYSIWYG (contenteditable) mode destroyed the markdown table — the formatting was lost/removed.

## Root cause

On every input, [editor.js](media/editor.js) converts the preview's HTML back to markdown via Turndown (the textarea is the source of truth). Turndown's **core has no table support**, so a `<table>` was flattened to plain concatenated cell text with no pipes or header separator. That corrupted text became the saved source — the table was gone after the next re-render (hence "sometimes").

## Fix

Added self-contained GFM table rules to the `TurndownService` (`tableCell`, `tableRow`, `tableSection`, `table`), adapted from `turndown-plugin-gfm` — no new dependency. It:

- Emits the header separator row (`| --- |`)
- Preserves column alignment — reads both the `align` attribute **and** `text-align` style, since markdown-it renders alignment as inline styles
- Keeps inline cell formatting (bold/italic/links/wikilinks)
- Escapes literal `|` in cell content and collapses newlines so cells stay single-line
- Only converts tables that have a heading row (others fall back to default handling)

## Verification

- Round-trip test (markdown → markdown-it HTML → Turndown → markdown) passes for basic, aligned, inline-formatted, and escaped-pipe tables
- `npm run compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)