### PR TITLE
fix: review hardening + tests for table-edit fix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,7 @@
 .claude/**
 .askance/**
 src/**
+tests/**
 node_modules/**
 scripts/**
 tsconfig.json

--- a/log.md
+++ b/log.md
@@ -344,3 +344,24 @@ Uses a line-level LCS diff algorithm with no external dependencies.
   - Preserves header separator row, column alignment (reads both `align` attr and `text-align` style, since markdown-it emits inline styles), inline cell formatting, and escapes literal pipes.
   - Only tables with a heading row are converted (others left to default handling).
 - Verified with a markdown→html→markdown round-trip test (basic, aligned, inline, escaped-pipe cases all pass); `npm run compile` passes.
+
+## 2026-06-16 — Code review pass + tests (fix/review-fixes)
+
+Ran a parallel code review (webview + extension host) and fixed the high-confidence, low-risk findings:
+
+- **src/utils.ts**: `getNonce` now uses `crypto.randomBytes` (CSPRNG) instead of `Math.random` — CSP nonces must be unpredictable.
+- **media/turndownTableRules.js** (new): extracted the GFM table rules into a shared, unit-testable UMD module. Fixed a real interaction bug: pipes inside `[[wikilinks]]` are no longer escaped to `\|` (the editor preprocesses wikilinks into `<a>` before the table parser, so the pipe must stay literal; escaping it broke the wikilink regex).
+- **media/editor.js**: now calls `installTurndownTableRules(turndownService)` from the shared module.
+- **src/markdownEditorProvider.ts**: loads `turndownTableRules.js` via a nonce'd `<script>` before editor.js.
+- **src/wikilink/fileIndexService.ts**: per-URI debounce timers (a single shared timer dropped pending updates when a second file was edited within 500ms); register watchers BEFORE the initial scan (files changed during scan were missed); stem→path mapping is only deleted on removal if it still points at the removed file (duplicate-stem safety).
+- **src/extension.ts**: `.catch()` on the fire-and-forget `initialize()`.
+- **src/diff/diffAlgorithm.ts**: trim common prefix/suffix before the O(m*n) LCS, bounding memory/time for small changes in large files.
+
+Tests (new — Node built-in runner, zero new deps; `npm test`):
+- `tests/turndownTable.test.js` — render→edit→serialize round-trip for tables (basic, alignment, inline formatting, escaped pipes, wikilink-with-alias pipe preservation, idempotency, regression guard that proves the rules are what fix the bug).
+- `tests/diffAlgorithm.test.mjs` — diff correctness + the prefix/suffix-trimming isolation on a 5000-line file.
+- `.vscodeignore` excludes `tests/`; `package.json` adds `"test": "node --test ..."`.
+
+Deferred (documented, not fixed — higher risk / edge, to avoid destabilizing pre-release): markdownEditorProvider `isApplyingEdit` boolean race (recently-fixed cursor-sync area); renamePropagation for spaced `[[ link ]]` and duplicate stems; grammar-highlight first-occurrence `indexOf`; LanguageTool proxy CONNECT timeout.
+
+All 16 tests pass; `npm run check-types` and `npm run compile` pass.

--- a/media/editor.js
+++ b/media/editor.js
@@ -77,96 +77,11 @@
     },
   });
 
-  // Custom rules: GFM tables. Turndown's core has NO table support — without
-  // these rules a <table> is flattened to plain concatenated cell text, so
-  // editing a table in WYSIWYG mode destroys its markdown formatting. This is a
-  // self-contained adaptation of turndown-plugin-gfm's table rules.
-
-  /** Render a single cell, prefixing the row's leading `|`. */
-  function tableCellMarkup(content, node) {
-    const index = Array.prototype.indexOf.call(node.parentNode.childNodes, node);
-    const prefix = index === 0 ? '| ' : ' ';
-    // Cells must be single-line, and literal pipes have to be escaped so they
-    // aren't read as column separators.
-    const cellText = content.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|').trim();
-    return prefix + cellText + ' |';
-  }
-
-  /** A <tbody> with no preceding content-bearing <thead> acts as the header. */
-  function isFirstTbody(element) {
-    const previousSibling = element.previousSibling;
-    return (
-      element.nodeName === 'TBODY' &&
-      (!previousSibling ||
-        (previousSibling.nodeName === 'THEAD' && /^\s*$/i.test(previousSibling.textContent)))
-    );
-  }
-
-  /** Is this <tr> the table's heading row (the one followed by `---` separators)? */
-  function isHeadingRow(tr) {
-    if (!tr) return false;
-    const parent = tr.parentNode;
-    return (
-      parent.nodeName === 'THEAD' ||
-      (parent.firstChild === tr &&
-        (parent.nodeName === 'TABLE' || isFirstTbody(parent)) &&
-        Array.prototype.every.call(tr.childNodes, function (n) {
-          return n.nodeName === 'TH';
-        }))
-    );
-  }
-
-  turndownService.addRule('tableCell', {
-    filter: ['th', 'td'],
-    replacement: function (content, node) {
-      return tableCellMarkup(content, node);
-    },
-  });
-
-  /** Column alignment, from the `align` attribute or `text-align` style. */
-  function cellAlignment(node) {
-    const attr = node.getAttribute && node.getAttribute('align');
-    const style = (node.style && node.style.textAlign) || '';
-    return (attr || style || '').toLowerCase();
-  }
-
-  turndownService.addRule('tableRow', {
-    filter: 'tr',
-    replacement: function (content, node) {
-      let borderCells = '';
-      const alignMap = { left: ':---', right: '---:', center: ':---:' };
-      if (isHeadingRow(node)) {
-        for (let i = 0; i < node.childNodes.length; i++) {
-          const child = node.childNodes[i];
-          let border = '---';
-          const align = cellAlignment(child);
-          if (align) border = alignMap[align] || border;
-          borderCells += tableCellMarkup(border, child);
-        }
-      }
-      return '\n' + content + (borderCells ? '\n' + borderCells : '');
-    },
-  });
-
-  turndownService.addRule('tableSection', {
-    filter: ['thead', 'tbody', 'tfoot'],
-    replacement: function (content) {
-      return content;
-    },
-  });
-
-  // Only tables with a heading row can be expressed as GFM markdown; others
-  // are left to Turndown's default handling.
-  turndownService.addRule('table', {
-    filter: function (node) {
-      return node.nodeName === 'TABLE' && isHeadingRow(node.rows[0]);
-    },
-    replacement: function (content) {
-      // Collapse the blank line Turndown inserts between the header row and the
-      // separator so the table stays contiguous.
-      return '\n\n' + content.replace(/\n+/g, '\n') + '\n\n';
-    },
-  });
+  // GFM table rules (Turndown's core has no table support). Defined in the
+  // shared media/turndownTableRules.js module so the same logic can be unit
+  // tested. Loaded as a global by the preceding <script> tag.
+  // @ts-ignore - installTurndownTableRules is a global from turndownTableRules.js
+  installTurndownTableRules(turndownService);
 
   /** Check if the editor is in preview-only (WYSIWYG) mode */
   function isPreviewMode() {

--- a/media/turndownTableRules.js
+++ b/media/turndownTableRules.js
@@ -1,0 +1,123 @@
+// @ts-nocheck
+// GFM table rules for Turndown (HTML -> Markdown).
+//
+// Turndown's core has NO table support — without these rules a <table> is
+// flattened to plain concatenated cell text, so editing a table in WYSIWYG
+// mode destroys its markdown formatting. This is a self-contained adaptation
+// of turndown-plugin-gfm's table rules.
+//
+// Exposed as a UMD-style module so it can be loaded both by the webview
+// (as a global `installTurndownTableRules`) and by the Node test runner
+// (via `require`).
+(function (global) {
+  'use strict';
+
+  /**
+   * Serialize a single cell, prefixing the row's leading `|`.
+   * Pipes are escaped so they aren't read as column separators — EXCEPT pipes
+   * inside a [[wikilink|alias]], which this editor preprocesses into <a> tags
+   * before the markdown table parser ever runs, so they must stay literal.
+   */
+  function tableCellMarkup(content, node) {
+    const index = Array.prototype.indexOf.call(node.parentNode.childNodes, node);
+    const prefix = index === 0 ? '| ' : ' ';
+    const cellText = content
+      .replace(/\r?\n/g, ' ')
+      .replace(/\[\[[^\]]*\]\]|\|/g, function (m) {
+        return m === '|' ? '\\|' : m;
+      })
+      .trim();
+    return prefix + cellText + ' |';
+  }
+
+  /** A <tbody> with no preceding content-bearing <thead> acts as the header. */
+  function isFirstTbody(element) {
+    const previousSibling = element.previousSibling;
+    return (
+      element.nodeName === 'TBODY' &&
+      (!previousSibling ||
+        (previousSibling.nodeName === 'THEAD' && /^\s*$/.test(previousSibling.textContent)))
+    );
+  }
+
+  /** Is this <tr> the table's heading row (the one followed by `---` separators)? */
+  function isHeadingRow(tr) {
+    if (!tr) {
+      return false;
+    }
+    const parent = tr.parentNode;
+    return (
+      parent.nodeName === 'THEAD' ||
+      (parent.firstChild === tr &&
+        (parent.nodeName === 'TABLE' || isFirstTbody(parent)) &&
+        Array.prototype.every.call(tr.childNodes, function (n) {
+          return n.nodeName === 'TH';
+        }))
+    );
+  }
+
+  /** Column alignment, from the `align` attribute or `text-align` style. */
+  function cellAlignment(node) {
+    const attr = node.getAttribute && node.getAttribute('align');
+    const style = (node.style && node.style.textAlign) || '';
+    return (attr || style || '').toLowerCase();
+  }
+
+  function installTurndownTableRules(turndownService) {
+    turndownService.addRule('tableCell', {
+      filter: ['th', 'td'],
+      replacement: function (content, node) {
+        return tableCellMarkup(content, node);
+      },
+    });
+
+    turndownService.addRule('tableRow', {
+      filter: 'tr',
+      replacement: function (content, node) {
+        let borderCells = '';
+        const alignMap = { left: ':---', right: '---:', center: ':---:' };
+        if (isHeadingRow(node)) {
+          for (let i = 0; i < node.childNodes.length; i++) {
+            const child = node.childNodes[i];
+            if (child.nodeName !== 'TH' && child.nodeName !== 'TD') {
+              continue;
+            }
+            let border = '---';
+            const align = cellAlignment(child);
+            if (align) {
+              border = alignMap[align] || border;
+            }
+            borderCells += tableCellMarkup(border, child);
+          }
+        }
+        return '\n' + content + (borderCells ? '\n' + borderCells : '');
+      },
+    });
+
+    turndownService.addRule('tableSection', {
+      filter: ['thead', 'tbody', 'tfoot'],
+      replacement: function (content) {
+        return content;
+      },
+    });
+
+    // Only tables with a heading row can be expressed as GFM markdown; others
+    // are left to Turndown's default handling.
+    turndownService.addRule('table', {
+      filter: function (node) {
+        return node.nodeName === 'TABLE' && isHeadingRow(node.rows[0]);
+      },
+      replacement: function (content) {
+        // Collapse the blank line Turndown inserts between the header row and
+        // the separator so the table stays contiguous.
+        return '\n\n' + content.replace(/\n+/g, '\n') + '\n\n';
+      },
+    });
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { installTurndownTableRules };
+  } else {
+    global.installTurndownTableRules = installTurndownTableRules;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/package.json
+++ b/package.json
@@ -202,7 +202,8 @@
     "check-types": "tsc --noEmit",
     "watch": "npm run copy-vendor && node esbuild.js --watch",
     "package": "npm run check-types && npm run copy-vendor && node esbuild.js --production",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "node --test \"tests/**/*.test.{js,mjs}\""
   },
   "devDependencies": {
     "@askance/cli": "^0.3.5",

--- a/src/diff/diffAlgorithm.ts
+++ b/src/diff/diffAlgorithm.ts
@@ -14,8 +14,62 @@ export function computeLineDiff(oldText: string, newText: string): DiffHunk[] {
   const oldLines = oldText.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
   const newLines = newText.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
 
+  // Trim the common prefix and suffix before running the O(m*n) LCS. For the
+  // typical case (a small change inside a large file) this collapses the DP to
+  // just the changed region, avoiding a quadratic-size table that could OOM the
+  // extension host on large documents.
+  const entries: { type: DiffHunk['type']; value: string }[] = [];
+
+  let prefix = 0;
+  const minLen = Math.min(oldLines.length, newLines.length);
+  while (prefix < minLen && oldLines[prefix] === newLines[prefix]) {
+    entries.push({ type: 'unchanged', value: oldLines[prefix] });
+    prefix++;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < minLen - prefix &&
+    oldLines[oldLines.length - 1 - suffix] === newLines[newLines.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+
+  const oldMid = oldLines.slice(prefix, oldLines.length - suffix);
+  const newMid = newLines.slice(prefix, newLines.length - suffix);
+
+  entries.push(...computeMidDiff(oldMid, newMid));
+
+  for (let s = suffix - 1; s >= 0; s--) {
+    entries.push({ type: 'unchanged', value: oldLines[oldLines.length - 1 - s] });
+  }
+
+  // Group consecutive same-type entries into hunks
+  const hunks: DiffHunk[] = [];
+  for (const entry of entries) {
+    const last = hunks[hunks.length - 1];
+    if (last && last.type === entry.type) {
+      last.content += '\n' + entry.value;
+    } else {
+      hunks.push({ type: entry.type, content: entry.value });
+    }
+  }
+
+  return hunks;
+}
+
+/** LCS diff of the two already-prefix/suffix-trimmed middle sections. */
+function computeMidDiff(
+  oldLines: string[],
+  newLines: string[],
+): { type: DiffHunk['type']; value: string }[] {
   const m = oldLines.length;
   const n = newLines.length;
+  const entries: { type: DiffHunk['type']; value: string }[] = [];
+
+  if (m === 0 && n === 0) {
+    return entries;
+  }
 
   // Build LCS table
   const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
@@ -31,7 +85,6 @@ export function computeLineDiff(oldText: string, newText: string): DiffHunk[] {
   }
 
   // Backtrack to produce per-line diff entries
-  const entries: { type: DiffHunk['type']; value: string }[] = [];
   let i = m;
   let j = n;
 
@@ -50,17 +103,5 @@ export function computeLineDiff(oldText: string, newText: string): DiffHunk[] {
   }
 
   entries.reverse();
-
-  // Group consecutive same-type entries into hunks
-  const hunks: DiffHunk[] = [];
-  for (const entry of entries) {
-    const last = hunks[hunks.length - 1];
-    if (last && last.type === entry.type) {
-      last.content += '\n' + entry.value;
-    } else {
-      hunks.push({ type: entry.type, content: entry.value });
-    }
-  }
-
-  return hunks;
+  return entries;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,9 @@ export function activate(context: vscode.ExtensionContext): void {
   // 1. Create the file index service (shared foundation for wikilinks + graph)
   const fileIndexService = new FileIndexService();
   context.subscriptions.push(fileIndexService);
-  fileIndexService.initialize();
+  fileIndexService.initialize().catch(err => {
+    console.error('[MarkdownEditor] FileIndexService initialization failed:', err);
+  });
 
   // 2. Register the custom markdown editor
   const provider = new MarkdownEditorProvider(context, fileIndexService);

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -199,6 +199,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     const turndownUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this.context.extensionUri, 'media', 'turndown.browser.umd.js')
     );
+    const tableRulesUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.context.extensionUri, 'media', 'turndownTableRules.js')
+    );
 
     return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -260,6 +263,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   </div>
   <script nonce="${nonce}" src="${markdownItUri}?v=${cacheBust}"></script>
   <script nonce="${nonce}" src="${turndownUri}?v=${cacheBust}"></script>
+  <script nonce="${nonce}" src="${tableRulesUri}?v=${cacheBust}"></script>
   <script nonce="${nonce}" src="${scriptUri}?v=${cacheBust}"></script>
 </body>
 </html>`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,12 @@
+import { randomBytes } from 'crypto';
+
 /**
  * Generate a random nonce for Content Security Policy in webviews.
+ * Uses a cryptographically secure RNG, as the CSP spec requires — a
+ * predictable nonce (e.g. Math.random) would weaken the policy.
  */
 export function getNonce(): string {
-  let text = '';
-  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  for (let i = 0; i < 64; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
+  return randomBytes(48).toString('base64').replace(/[^A-Za-z0-9]/g, '').slice(0, 64);
 }
 
 /**

--- a/src/wikilink/fileIndexService.ts
+++ b/src/wikilink/fileIndexService.ts
@@ -33,7 +33,10 @@ export class FileIndexService implements vscode.Disposable {
   public readonly onDidUpdateIndex = this._onDidUpdateIndex.event;
 
   private disposables: vscode.Disposable[] = [];
-  private updateTimer: ReturnType<typeof setTimeout> | undefined;
+  /** Per-document debounce timers, keyed by URI string. A single shared timer
+   * would drop a pending update for file A when file B is edited within the
+   * debounce window. */
+  private updateTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
   constructor() {
     this.disposables.push(this._onDidUpdateIndex);
@@ -41,6 +44,11 @@ export class FileIndexService implements vscode.Disposable {
 
   /** Full workspace scan. Call once on activation. */
   public async initialize(): Promise<void> {
+    // Register watchers BEFORE the (potentially slow) initial scan so files
+    // created/saved/renamed while scanning are not missed. Re-indexing a file
+    // is idempotent, so any overlap with the scan is harmless.
+    this.registerWatchers();
+
     const uris = await vscode.workspace.findFiles('**/*.md', '**/node_modules/**');
 
     // Process in batches to avoid overwhelming the file system
@@ -50,7 +58,6 @@ export class FileIndexService implements vscode.Disposable {
       await Promise.all(batch.map(uri => this.indexFile(uri)));
     }
 
-    this.registerWatchers();
     this._onDidUpdateIndex.fire();
   }
 
@@ -121,15 +128,20 @@ export class FileIndexService implements vscode.Disposable {
           if (e.contentChanges.length === 0) {
             return;
           }
-          if (this.updateTimer) {
-            clearTimeout(this.updateTimer);
+          const key = e.document.uri.toString();
+          const existing = this.updateTimers.get(key);
+          if (existing) {
+            clearTimeout(existing);
           }
-          this.updateTimer = setTimeout(() => {
-            this.updateTimer = undefined;
-            this.indexFile(e.document.uri, e.document.getText()).then(() => {
-              this._onDidUpdateIndex.fire();
-            });
-          }, 500);
+          this.updateTimers.set(
+            key,
+            setTimeout(() => {
+              this.updateTimers.delete(key);
+              this.indexFile(e.document.uri, e.document.getText()).then(() => {
+                this._onDidUpdateIndex.fire();
+              });
+            }, 500),
+          );
         }
       })
     );
@@ -196,7 +208,12 @@ export class FileIndexService implements vscode.Disposable {
     const entry = this.fileIndex.get(relativePath);
     if (entry) {
       this.removeBacklinks(relativePath, entry.outgoingLinks);
-      this.stemToPath.delete(entry.stem.toLowerCase());
+      // Only drop the stem->path mapping if it still points at THIS file —
+      // another file sharing the same stem may currently own the mapping.
+      const stemKey = entry.stem.toLowerCase();
+      if (this.stemToPath.get(stemKey) === relativePath) {
+        this.stemToPath.delete(stemKey);
+      }
       this.fileIndex.delete(relativePath);
     }
   }
@@ -322,9 +339,10 @@ export class FileIndexService implements vscode.Disposable {
   }
 
   public dispose(): void {
-    if (this.updateTimer) {
-      clearTimeout(this.updateTimer);
+    for (const timer of this.updateTimers.values()) {
+      clearTimeout(timer);
     }
+    this.updateTimers.clear();
     for (const d of this.disposables) {
       d.dispose();
     }

--- a/tests/diffAlgorithm.test.mjs
+++ b/tests/diffAlgorithm.test.mjs
@@ -1,0 +1,84 @@
+// Tests for the line-level diff used by the version-diff viewer. Also guards the
+// common-prefix/suffix trimming optimization (which avoids a quadratic LCS table
+// blowing up the extension host on large files).
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+// Imported from TypeScript source directly — Node strips the types.
+const { computeLineDiff } = await import('../src/diff/diffAlgorithm.ts');
+
+/** Reconstruct the "old" text from the hunks (unchanged + removed lines). */
+function reconstructOld(hunks) {
+  return hunks
+    .filter((h) => h.type !== 'added')
+    .map((h) => h.content)
+    .join('\n');
+}
+
+/** Reconstruct the "new" text from the hunks (unchanged + added lines). */
+function reconstructNew(hunks) {
+  return hunks
+    .filter((h) => h.type !== 'removed')
+    .map((h) => h.content)
+    .join('\n');
+}
+
+test('identical text produces a single unchanged hunk', () => {
+  const text = 'a\nb\nc';
+  const hunks = computeLineDiff(text, text);
+  assert.strictEqual(hunks.length, 1);
+  assert.strictEqual(hunks[0].type, 'unchanged');
+  assert.strictEqual(hunks[0].content, 'a\nb\nc');
+});
+
+test('pure addition', () => {
+  const hunks = computeLineDiff('a\nc', 'a\nb\nc');
+  assert.strictEqual(reconstructOld(hunks), 'a\nc');
+  assert.strictEqual(reconstructNew(hunks), 'a\nb\nc');
+  assert.ok(hunks.some((h) => h.type === 'added' && h.content === 'b'));
+});
+
+test('pure deletion', () => {
+  const hunks = computeLineDiff('a\nb\nc', 'a\nc');
+  assert.strictEqual(reconstructOld(hunks), 'a\nb\nc');
+  assert.strictEqual(reconstructNew(hunks), 'a\nc');
+  assert.ok(hunks.some((h) => h.type === 'removed' && h.content === 'b'));
+});
+
+test('a change in the middle of a large file only diffs the changed region', () => {
+  const big = Array.from({ length: 5000 }, (_, i) => `line ${i}`);
+  const oldText = big.join('\n');
+  const changed = big.slice();
+  changed[2500] = 'CHANGED LINE';
+  const newText = changed.join('\n');
+
+  const hunks = computeLineDiff(oldText, newText);
+
+  // Round-trips correctly...
+  assert.strictEqual(reconstructOld(hunks), oldText);
+  assert.strictEqual(reconstructNew(hunks), newText);
+  // ...and the change is isolated: exactly one removed + one added line.
+  const removed = hunks.filter((h) => h.type === 'removed');
+  const added = hunks.filter((h) => h.type === 'added');
+  assert.strictEqual(removed.length, 1);
+  assert.strictEqual(added.length, 1);
+  assert.strictEqual(removed[0].content, 'line 2500');
+  assert.strictEqual(added[0].content, 'CHANGED LINE');
+});
+
+test('CRLF and LF are normalized so line endings alone are not a diff', () => {
+  const hunks = computeLineDiff('a\r\nb\r\nc', 'a\nb\nc');
+  assert.strictEqual(hunks.length, 1);
+  assert.strictEqual(hunks[0].type, 'unchanged');
+});
+
+test('completely different text', () => {
+  const hunks = computeLineDiff('x\ny', 'p\nq');
+  assert.strictEqual(reconstructOld(hunks), 'x\ny');
+  assert.strictEqual(reconstructNew(hunks), 'p\nq');
+});
+
+test('empty old text (all added)', () => {
+  const hunks = computeLineDiff('', 'a\nb');
+  assert.strictEqual(reconstructNew(hunks), 'a\nb');
+});

--- a/tests/turndownTable.test.js
+++ b/tests/turndownTable.test.js
@@ -1,0 +1,136 @@
+// Round-trip tests for the WYSIWYG table fix.
+//
+// In WYSIWYG mode the editor renders markdown -> HTML (markdown-it), the user
+// edits the HTML (contenteditable), and Turndown converts it back to markdown.
+// Turndown has no native table support, so without the rules in
+// media/turndownTableRules.js a table is flattened and destroyed. These tests
+// exercise the exact render->edit->serialize pipeline to ensure tables (and the
+// editor's wikilink syntax) survive an edit.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const MarkdownIt = require('markdown-it');
+const TurndownService = require('turndown');
+const { installTurndownTableRules } = require('../media/turndownTableRules.js');
+
+/** Build markdown-it + Turndown configured like media/editor.js. */
+function makeServices(withTableRules = true) {
+  const md = new MarkdownIt({ html: true, linkify: true, typographer: true, breaks: true });
+  const td = new TurndownService({
+    headingStyle: 'atx',
+    hr: '---',
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '*',
+    strongDelimiter: '**',
+  });
+  // Mirror the wikilink rule from editor.js so cell interactions are realistic.
+  td.addRule('wikilink', {
+    filter: (node) => node.nodeName === 'A' && node.classList.contains('wikilink'),
+    replacement: (content, node) => {
+      const target = node.getAttribute('data-target');
+      return content === target ? '[[' + target + ']]' : '[[' + target + '|' + content + ']]';
+    },
+  });
+  if (withTableRules) {
+    installTurndownTableRules(td);
+  }
+  return { md, td };
+}
+
+/** Mirror of editor.js preprocessWikilinks (runs before markdown-it). */
+function preprocessWikilinks(text) {
+  return text.replace(/\[\[([^\]|]+?)(?:\|([^\]]*?))?\]\]/g, (m, target, display) => {
+    const label = display || target;
+    return '<a class="wikilink" data-target="' + target.trim() + '">' + label.trim() + '</a>';
+  });
+}
+
+/** Full render -> serialize round trip, returning the resulting markdown. */
+function roundTrip(src, withTableRules = true) {
+  const { md, td } = makeServices(withTableRules);
+  const html = md.render(preprocessWikilinks(src));
+  return td.turndown(html).trim();
+}
+
+/** A markdown string is a GFM table if it has a row and a separator row. */
+function looksLikeTable(mdText) {
+  const lines = mdText.split('\n').filter((l) => l.trim().startsWith('|'));
+  const hasSeparator = lines.some((l) => /\|[\s:-]+\|/.test(l) && l.includes('-'));
+  return lines.length >= 2 && hasSeparator;
+}
+
+test('basic table survives the round trip', () => {
+  const src = '| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |';
+  const out = roundTrip(src);
+  assert.ok(looksLikeTable(out), `expected a table, got:\n${out}`);
+  assert.match(out, /\| Alice \| 30 \|/);
+  assert.match(out, /\| Bob \| 25 \|/);
+});
+
+test('column alignment is preserved', () => {
+  const src = '| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |';
+  const out = roundTrip(src);
+  assert.match(out, /\| :--- \| :---: \| ---: \|/, `alignment lost:\n${out}`);
+});
+
+test('inline formatting inside cells is preserved', () => {
+  const src = '| Col |\n| --- |\n| **bold** and *italic* |';
+  const out = roundTrip(src);
+  assert.match(out, /\*\*bold\*\*/);
+  assert.match(out, /\*italic\*/);
+  assert.ok(looksLikeTable(out));
+});
+
+test('literal pipes in cell text are escaped', () => {
+  const src = '| A | B |\n| --- | --- |\n| has \\| pipe | ok |';
+  const out = roundTrip(src);
+  assert.match(out, /has \\\| pipe/, `pipe not escaped:\n${out}`);
+  // Re-rendering the escaped output must still be a single 2-column table.
+  assert.ok(looksLikeTable(roundTrip(out)));
+});
+
+test('wikilink with alias inside a cell keeps its pipe UNescaped', () => {
+  // The editor preprocesses [[a|b]] into <a> before the table parser runs, so
+  // the pipe must stay literal — escaping it to \| breaks the wikilink regex.
+  const src = '| Link |\n| --- |\n| [[Note|Display]] |';
+  const out = roundTrip(src);
+  assert.match(out, /\[\[Note\|Display\]\]/, `wikilink mangled:\n${out}`);
+  assert.doesNotMatch(out, /\[\[Note\\\|Display\]\]/, 'wikilink pipe was wrongly escaped');
+});
+
+test('plain wikilink (no alias) inside a cell is preserved', () => {
+  const src = '| Link |\n| --- |\n| [[Note]] |';
+  const out = roundTrip(src);
+  assert.match(out, /\[\[Note\]\]/);
+});
+
+test('round trip is idempotent (repeated edits do not corrupt the table)', () => {
+  const cases = [
+    '| Name | Age |\n| --- | --- |\n| Alice | 30 |',
+    '| Left | Right |\n| :--- | ---: |\n| a | b |',
+    '| Link |\n| --- |\n| [[Note|Display]] |',
+  ];
+  for (const src of cases) {
+    const once = roundTrip(src);
+    const twice = roundTrip(once);
+    assert.strictEqual(twice, once, `not idempotent for:\n${src}`);
+  }
+});
+
+test('regression guard: without the table rules a table IS destroyed', () => {
+  // Proves the rules are what fix the bug — not markdown-it/turndown defaults.
+  const src = '| Name | Age |\n| --- | --- |\n| Alice | 30 |';
+  const out = roundTrip(src, /* withTableRules */ false);
+  assert.ok(!looksLikeTable(out), `table unexpectedly survived without rules:\n${out}`);
+});
+
+test('non-table content is unaffected by the table rules', () => {
+  const src = '# Heading\n\nA paragraph with **bold** text.\n\n- item one\n- item two';
+  const out = roundTrip(src);
+  assert.match(out, /# Heading/);
+  assert.match(out, /\*\*bold\*\*/);
+  assert.match(out, /-\s+item one/);
+  assert.match(out, /-\s+item two/);
+});

--- a/todo.md
+++ b/todo.md
@@ -114,3 +114,13 @@
 - [ ] PR develop → master, merge
 - [x] Publish 0.2.1 from master to VS Code Marketplace
 - [x] Fix WYSIWYG table formatting loss (Turndown GFM table rules)
+
+## Code review pass (fix/review-fixes)
+
+- [x] getNonce → CSPRNG
+- [x] Extract + unit-test Turndown table rules; fix wikilink pipe in cells
+- [x] fileIndexService: per-URI debounce, watchers-before-scan, stem-safe removal
+- [x] extension: catch initialize() rejection
+- [x] diffAlgorithm: prefix/suffix trim
+- [x] Add Node test runner + table & diff tests
+- [ ] Follow-ups (deferred): editor cursor-sync race, rename edge cases, grammar highlight offset, LT proxy timeout


### PR DESCRIPTION
## Summary

A code-review pass over the webview and extension host, fixing the high-confidence, low-risk findings, plus a first test suite (Node's built-in runner — **no new dependencies**) that guards the WYSIWYG table-edit fix and the diff algorithm.

## Fixes

| Area | Change |
|------|--------|
| `src/utils.ts` | `getNonce` uses `crypto.randomBytes` instead of `Math.random` — CSP nonces must be unpredictable |
| `media/turndownTableRules.js` (new) | Extracted the GFM table rules into a shared, unit-testable module. **Bug fix:** pipes inside `[[wikilinks]]` are no longer escaped to `\|` — the editor preprocesses wikilinks into `<a>` before the table parser runs, so the pipe must stay literal; escaping it broke the wikilink round-trip |
| `media/editor.js` | Calls `installTurndownTableRules(...)` from the shared module |
| `src/markdownEditorProvider.ts` | Loads the new module via a nonce'd `<script>` before editor.js |
| `src/wikilink/fileIndexService.ts` | Per-URI debounce timers (a single shared timer dropped a pending update when a second file was edited within 500ms); register watchers **before** the initial scan (changes during scan were missed); delete the stem→path mapping only when it still points at the removed file (duplicate-stem safety) |
| `src/extension.ts` | `.catch()` the fire-and-forget `initialize()` |
| `src/diff/diffAlgorithm.ts` | Trim common prefix/suffix before the O(m·n) LCS — bounds memory/time for small edits in large files |

## Tests (`npm test`)

- `tests/turndownTable.test.js` — render→edit→serialize round-trip: basic tables, column alignment, inline formatting, escaped pipes, **wikilink-with-alias pipe preservation**, idempotency (repeated edits don't corrupt), and a regression guard proving the rules are what fix the bug.
- `tests/diffAlgorithm.test.mjs` — diff correctness + prefix/suffix-trim isolation on a 5000-line file.
- 16 tests, all passing. `.vscodeignore` excludes `tests/`.

## Deferred (documented, intentionally not fixed pre-release)

Higher-risk or edge findings left as follow-ups to avoid destabilizing the release: the `isApplyingEdit` boolean race in the recently-fixed cursor-sync path; rename propagation for spaced `[[ link ]]` and duplicate stems; grammar-highlight first-occurrence `indexOf`; LanguageTool proxy CONNECT timeout.

## Verification

- `npm test` — 16/16 pass
- `npm run check-types` and `npm run compile` pass
- `vsce ls` confirms `media/turndownTableRules.js` ships and tests are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)