### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [0.2.2] - 2026-06-16
+
+### Fixed
+
+- Preserve table formatting when editing tables in WYSIWYG mode (#29).
+- Keep `[[wikilink|alias]]` syntax intact when used inside a table cell.
+- Use a cryptographically secure nonce for the webview Content Security Policy.
+- File index: debounce per-document so rapid edits across files aren't dropped; index files changed during the initial workspace scan.
+- Bound memory/time of the version-diff algorithm on large files.
+
+### Added
+
+- Unit test suite (`npm test`) covering the table round-trip and diff algorithm.
+
 ## [0.2.1] - 2026-06-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "publisher": "advancer-limited",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary

Patch version bump 0.2.1 → 0.2.2 for the next marketplace release.

Bundles: the WYSIWYG table-edit fix (#29), the wikilink-in-table-cell fix, review hardening (CSP nonce, per-file index debounce, diff bounds), and the new test suite (#30).

## Changes

- `package.json` / `package-lock.json` — 0.2.1 → 0.2.2
- `CHANGELOG.md` — 0.2.2 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)