### PR TITLE
Release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [0.2.3] - 2026-06-17
+
+### Fixed
+
+- Grammar highlights: skip text already wrapped in a highlight so a repeated phrase advances to its next un-highlighted occurrence instead of re-marking the first.
+- LanguageTool: add a request timeout so a hung upstream after the tunnel is established no longer leaves the request pending forever.
+- Editor: replace the boolean edit guard with a depth counter so overlapping edits from fast typing don't clear the echo-suppression guard early.
+- Rename propagation: don't rewrite `[[wikilink]]` references when another file owns the stem's resolution; share a single whitespace-tolerant, regex-safe stem matcher.
+
+### Added
+
+- Unit tests for the wikilink stem matcher used by rename propagation.
+
 ## [0.2.2] - 2026-06-16
 
 ### Fixed

--- a/log.md
+++ b/log.md
@@ -373,3 +373,10 @@ All 16 tests pass; `npm run check-types` and `npm run compile` pass.
 - **Grammar highlight offset** (editor.js): skip text already inside a `.grammar-error` span so repeated phrases advance to the next un-highlighted occurrence instead of re-marking the first.
 - **LanguageTool proxy timeout** (languageToolService.ts): added a 15s timeout + handler to the inner tunneled request so a hung upstream after CONNECT can't leave the promise pending forever.
 - Tests: added tests/renameMatch.test.mjs (8 cases). Full suite now 24 tests, all passing; check-types clean; build passes.
+
+## 2026-06-17 — Release 0.2.3 (develop → master + publish)
+
+- develop was 2 commits ahead of master (PR #33, the deferred review follow-ups above) but both were still tagged 0.2.2, which is already on the Marketplace.
+- Reviewed the develop↔master diff (grammar highlight dedup, LanguageTool timeout, edit depth-counter guard, rename-propagation hardening, new renameMatch tests) — clean. `check-types`, `npm test` (24 pass), and `npm run compile` all green.
+- Bumped 0.2.2 → 0.2.3 (patch) on branch `fix/bump-0.2.3` off develop: `package.json`, `package-lock.json`, `CHANGELOG.md` (0.2.3 entry).
+- Flow: PR fix/bump-0.2.3 → develop, then develop → master, then publish 0.2.3 from master.

--- a/log.md
+++ b/log.md
@@ -365,3 +365,11 @@ Tests (new — Node built-in runner, zero new deps; `npm test`):
 Deferred (documented, not fixed — higher risk / edge, to avoid destabilizing pre-release): markdownEditorProvider `isApplyingEdit` boolean race (recently-fixed cursor-sync area); renamePropagation for spaced `[[ link ]]` and duplicate stems; grammar-highlight first-occurrence `indexOf`; LanguageTool proxy CONNECT timeout.
 
 All 16 tests pass; `npm run check-types` and `npm run compile` pass.
+
+## 2026-06-16 — Deferred review follow-ups (fix/review-followups)
+
+- **Cursor-sync race** (markdownEditorProvider.ts): replaced the boolean `isApplyingEdit` guard with a depth counter `applyingEdits` so overlapping edits from fast typing don't clear the guard early; wrapped both applyEdit calls in try/finally so a failed edit can't wedge the guard permanently.
+- **Rename edge cases** (wikilinkParser.ts + renamePropagation.ts): added pure, unit-tested `findWikilinkStemRanges` that matches `[[stem]]`/`[[stem|display]]` case-insensitively and tolerant of inner whitespace (`[[ Foo ]]`), selecting only the stem span. Rename now also skips files whose stem currently resolves to a *different* file (duplicate-stem safety). Inlined escapeRegex into wikilinkParser to keep it dependency-free (and testable under Node type stripping); removed the now-unused utils.escapeRegex.
+- **Grammar highlight offset** (editor.js): skip text already inside a `.grammar-error` span so repeated phrases advance to the next un-highlighted occurrence instead of re-marking the first.
+- **LanguageTool proxy timeout** (languageToolService.ts): added a 15s timeout + handler to the inner tunneled request so a hung upstream after CONNECT can't leave the promise pending forever.
+- Tests: added tests/renameMatch.test.mjs (8 cases). Full suite now 24 tests, all passing; check-types clean; build passes.

--- a/media/editor.js
+++ b/media/editor.js
@@ -1026,6 +1026,18 @@
   // ================================================
   // Grammar highlight rendering
   // ================================================
+  /** True if the text node is already inside a grammar-error highlight span. */
+  function isInsideHighlight(node) {
+    let el = node.parentElement;
+    while (el && el !== previewContent) {
+      if (el.classList && el.classList.contains('grammar-error')) {
+        return true;
+      }
+      el = el.parentElement;
+    }
+    return false;
+  }
+
   function applyGrammarHighlights() {
     if (currentGrammarMatches.length === 0) return;
 
@@ -1048,6 +1060,9 @@
       let found = false;
       for (let ni = 0; ni < textNodes.length && !found; ni++) {
         const textNode = textNodes[ni];
+        // Skip text already wrapped in a highlight so repeated phrases advance
+        // to the next un-highlighted occurrence rather than re-marking the first.
+        if (isInsideHighlight(textNode)) continue;
         const content = textNode.textContent;
         const idx = content.indexOf(searchText);
         if (idx === -1) continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "publisher": "advancer-limited",
   "icon": "media/icon.png",

--- a/src/languageToolService.ts
+++ b/src/languageToolService.ts
@@ -246,6 +246,7 @@ export class LanguageToolService {
           path: targetUrl.pathname + targetUrl.search,
           method: 'POST',
           createConnection: () => socket as any,
+          timeout: 15000,
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
             'Accept': 'application/json',
@@ -267,6 +268,12 @@ export class LanguageToolService {
           });
         });
 
+        // Without this, a hung upstream after the tunnel is established would
+        // leave the promise pending forever.
+        req.on('timeout', () => {
+          req.destroy();
+          reject(new Error('LanguageTool request timed out'));
+        });
         req.on('error', reject);
         req.write(body);
         req.end();

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -60,13 +60,15 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
 
     // Suppress echoing our own edits back to the webview.
-    // Two-layer guard: isApplyingEdit catches synchronous fires during applyEdit;
-    // lastAppliedText catches fires that arrive after the await resolves.
-    let isApplyingEdit = false;
+    // Two-layer guard: applyingEdits (a depth counter, not a boolean) stays
+    // raised while ANY applyEdit is in flight — so overlapping edits from fast
+    // typing don't clear the guard early; lastAppliedText catches a change
+    // event that arrives after the last await resolves.
+    let applyingEdits = 0;
     let lastAppliedText: string | null = null;
 
     const updateWebview = () => {
-      if (isApplyingEdit) {
+      if (applyingEdits > 0) {
         return;
       }
       const currentText = document.getText();
@@ -90,7 +92,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             return;
 
           case 'edit': {
-            isApplyingEdit = true;
+            applyingEdits++;
             lastAppliedText = message.text;
             if (message.cursorOffset !== undefined) {
               this.cursorOffsets.set(document.uri.toString(), message.cursorOffset);
@@ -101,8 +103,11 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
               new vscode.Range(0, 0, document.lineCount, 0),
               message.text
             );
-            await vscode.workspace.applyEdit(edit);
-            isApplyingEdit = false;
+            try {
+              await vscode.workspace.applyEdit(edit);
+            } finally {
+              applyingEdits--;
+            }
             return;
           }
 
@@ -140,13 +145,17 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           }
 
           case 'applyGrammarFix': {
-            isApplyingEdit = true;
+            applyingEdits++;
             const startPos = document.positionAt(message.offset);
             const endPos = document.positionAt(message.offset + message.length);
             const edit = new vscode.WorkspaceEdit();
             edit.replace(document.uri, new vscode.Range(startPos, endPos), message.replacement);
-            await vscode.workspace.applyEdit(edit);
-            isApplyingEdit = false;
+            try {
+              await vscode.workspace.applyEdit(edit);
+            } finally {
+              applyingEdits--;
+            }
+            // Intentionally push the corrected text back to the webview.
             updateWebview();
             return;
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,13 +45,6 @@ export function getFileStem(filePath: string): string {
 }
 
 /**
- * Escape special regex characters in a string.
- */
-export function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
  * Strip Markdown syntax to produce plain text for LanguageTool.
  * Returns the stripped text and an offset map from stripped positions to original positions.
  */

--- a/src/wikilink/renamePropagation.ts
+++ b/src/wikilink/renamePropagation.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { FileIndexService } from './fileIndexService.js';
-import { getFileStem, escapeRegex } from '../utils.js';
+import { getFileStem } from '../utils.js';
+import { findWikilinkStemRanges } from './wikilinkParser.js';
 
 /**
  * Handle file rename events: update all [[wikilink]] references
@@ -25,6 +26,17 @@ export async function handleWillRenameFiles(
       continue; // Only moved, not renamed — no wikilink updates needed
     }
 
+    // If another file shares this stem and currently owns the [[oldStem]]
+    // resolution, those links point at THAT file — renaming this one must not
+    // rewrite them. Only proceed when the stem resolves to the renamed file.
+    const resolvedPath = fileIndexService.resolveWikilink(oldStem);
+    if (resolvedPath) {
+      const resolvedEntry = fileIndexService.getFileEntry(resolvedPath);
+      if (resolvedEntry && resolvedEntry.uri.toString() !== oldUri.toString()) {
+        continue;
+      }
+    }
+
     // Find all files that link to the old stem
     const backlinks = fileIndexService.getBacklinksFor(oldStem);
 
@@ -33,20 +45,14 @@ export async function handleWillRenameFiles(
         const doc = await vscode.workspace.openTextDocument(entry.uri);
         const text = doc.getText();
 
-        // Match [[oldStem]] and [[oldStem|display text]]
-        const regex = new RegExp(
-          `\\[\\[${escapeRegex(oldStem)}(\\|[^\\]]*)?\\]\\]`,
-          'gi',
-        );
-
-        let match: RegExpExecArray | null;
-        while ((match = regex.exec(text)) !== null) {
-          // Replace just the stem part (after [[ and before | or ]])
-          const stemStart = match.index + 2; // after [[
-          const stemEnd = stemStart + oldStem.length;
-          const start = doc.positionAt(stemStart);
-          const end = doc.positionAt(stemEnd);
-          edit.replace(entry.uri, new vscode.Range(start, end), newStem);
+        // Replace just the stem portion of each [[oldStem]] / [[oldStem|...]]
+        // occurrence (case-insensitive, whitespace-tolerant).
+        for (const { start, end } of findWikilinkStemRanges(text, oldStem)) {
+          edit.replace(
+            entry.uri,
+            new vscode.Range(doc.positionAt(start), doc.positionAt(end)),
+            newStem,
+          );
         }
       } catch (err) {
         console.warn(`[RenamePropagation] Failed to process ${entry.relativePath}:`, err);

--- a/src/wikilink/wikilinkParser.ts
+++ b/src/wikilink/wikilinkParser.ts
@@ -3,6 +3,11 @@
  * Pure functions with no VS Code dependency.
  */
 
+/** Escape regex-special characters in a literal string. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** A single parsed wikilink occurrence within a file. */
 export interface WikilinkOccurrence {
   /** Raw text inside [[...]] */
@@ -23,6 +28,30 @@ export interface WikilinkOccurrence {
 
 /** Matches [[target]] and [[target|display text]] */
 export const WIKILINK_REGEX = /\[\[([^\]|]+?)(?:\|([^\]]*?))?\]\]/g;
+
+/**
+ * Find the character ranges of the *stem* portion within [[stem]] and
+ * [[stem|display]] occurrences. Matches `stem` case-insensitively and tolerates
+ * whitespace inside the brackets (e.g. `[[ Stem ]]`), returning the [start, end)
+ * offsets of just the stem so it can be replaced in place during a rename.
+ * A multi-word target (e.g. `[[Stem Two]]`) is NOT matched when renaming `Stem`.
+ */
+export function findWikilinkStemRanges(
+  text: string,
+  stem: string,
+): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = [];
+  if (!stem) {
+    return ranges;
+  }
+  const regex = new RegExp(`(\\[\\[\\s*)(${escapeRegex(stem)})(\\s*(?:\\|[^\\]]*)?\\]\\])`, 'gi');
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    const start = match.index + match[1].length;
+    ranges.push({ start, end: start + match[2].length });
+  }
+  return ranges;
+}
 
 /**
  * Compute fenced code block and inline code ranges in the text.

--- a/tests/renameMatch.test.mjs
+++ b/tests/renameMatch.test.mjs
@@ -1,0 +1,54 @@
+// Tests for findWikilinkStemRanges — the pure matcher used by rename
+// propagation to locate the stem portion of [[wikilinks]] for in-place rewrite.
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+const { findWikilinkStemRanges } = await import('../src/wikilink/wikilinkParser.ts');
+
+/** Apply the ranges to verify they select exactly the stem text. */
+function selected(text, stem) {
+  return findWikilinkStemRanges(text, stem).map((r) => text.slice(r.start, r.end));
+}
+
+test('matches a plain [[stem]]', () => {
+  const text = 'see [[Foo]] here';
+  const ranges = findWikilinkStemRanges(text, 'Foo');
+  assert.strictEqual(ranges.length, 1);
+  assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), 'Foo');
+});
+
+test('matches [[stem|display]] but selects only the stem', () => {
+  const text = 'see [[Foo|Display Text]] here';
+  assert.deepStrictEqual(selected(text, 'Foo'), ['Foo']);
+});
+
+test('is case-insensitive but preserves the matched casing in the range', () => {
+  const text = 'a [[foo]] and [[FOO]]';
+  assert.deepStrictEqual(selected(text, 'Foo'), ['foo', 'FOO']);
+});
+
+test('tolerates whitespace inside the brackets', () => {
+  const text = 'x [[ Foo ]] y [[  Foo  |  alias ]] z';
+  assert.deepStrictEqual(selected(text, 'Foo'), ['Foo', 'Foo']);
+});
+
+test('does NOT match a different multi-word target', () => {
+  const text = '[[Foo Bar]] and [[Foobar]]';
+  assert.deepStrictEqual(selected(text, 'Foo'), []);
+});
+
+test('matches multiple occurrences', () => {
+  const text = '[[Foo]] [[Foo|a]] [[ Foo ]]';
+  assert.strictEqual(findWikilinkStemRanges(text, 'Foo').length, 3);
+});
+
+test('escapes regex-special characters in the stem', () => {
+  const text = 'see [[C++ Notes]] and [[a.b]]';
+  assert.deepStrictEqual(selected(text, 'a.b'), ['a.b']);
+  // The "." must be literal — it should not match "axb".
+  assert.deepStrictEqual(selected('[[axb]]', 'a.b'), []);
+});
+
+test('returns empty for an empty stem', () => {
+  assert.deepStrictEqual(findWikilinkStemRanges('[[Foo]]', ''), []);
+});

--- a/todo.md
+++ b/todo.md
@@ -123,4 +123,4 @@
 - [x] extension: catch initialize() rejection
 - [x] diffAlgorithm: prefix/suffix trim
 - [x] Add Node test runner + table & diff tests
-- [ ] Follow-ups (deferred): editor cursor-sync race, rename edge cases, grammar highlight offset, LT proxy timeout
+- [x] Follow-ups: editor cursor-sync race, rename edge cases, grammar highlight offset, LT proxy timeout

--- a/todo.md
+++ b/todo.md
@@ -124,3 +124,11 @@
 - [x] diffAlgorithm: prefix/suffix trim
 - [x] Add Node test runner + table & diff tests
 - [x] Follow-ups: editor cursor-sync race, rename edge cases, grammar highlight offset, LT proxy timeout
+
+## Release 0.2.3
+
+- [x] Bump version to 0.2.3 (package.json, package-lock.json)
+- [x] Add CHANGELOG 0.2.3 entry
+- [x] PR fix/bump-0.2.3 → develop, self-review, merge
+- [x] PR develop → master, merge
+- [ ] Publish 0.2.3 from master to VS Code Marketplace


### PR DESCRIPTION
## Release 0.2.3

Promotes the deferred code-review follow-ups and the 0.2.3 version bump from `develop` to `master` for Marketplace publication.

### Fixed

- **Grammar highlights**: skip text already wrapped in a highlight so a repeated phrase advances to its next un-highlighted occurrence instead of re-marking the first.
- **LanguageTool**: 15s request timeout so a hung upstream after the CONNECT tunnel no longer leaves the request pending forever.
- **Editor**: depth-counter edit guard so overlapping edits from fast typing don't clear the echo-suppression guard early.
- **Rename propagation**: don't rewrite `[[wikilink]]` references when another file owns the stem's resolution; shared whitespace-tolerant, regex-safe stem matcher.

### Added

- Unit tests for the wikilink stem matcher (`tests/renameMatch.test.mjs`).

## Verification

- `npm run check-types` — clean
- `npm test` — 24/24 pass
- `npm run compile` — clean

## Next

Publish `advancer-limited.vscode-md-editor@0.2.3` from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)