### PR TITLE
fix: stop WYSIWYG cursor jumps during live editing

### DIFF
--- a/media/editor.js
+++ b/media/editor.js
@@ -33,6 +33,17 @@
   // Track whether the current content update originated from the extension host
   let isExternalUpdate = false;
 
+  // True while an IME composition is in progress in the contenteditable
+  // preview. Serializing/re-rendering mid-composition breaks the IME session
+  // and teleports the caret, so all sync work is deferred to compositionend.
+  let isComposing = false;
+
+  // The markdown most recently posted to the extension host, plus whether a
+  // debounced local edit is still waiting to be posted. Together these let the
+  // update handler recognize late echoes and stale snapshots (see 'update').
+  let lastSentEditText = null;
+  let localEditPending = false;
+
   // Stored frontmatter to preserve during contenteditable round-trips
   let currentFrontmatter = '';
 
@@ -185,7 +196,16 @@
         // text genuinely differs — i.e. a real external change (other editor,
         // git, grammar fix, etc.). This replaces the old isContentEditableUpdate
         // flag, which could get stuck and silently drop external updates.
-        const isEcho = text === textarea.value;
+        const isEcho = text === textarea.value || text === lastSentEditText;
+        if (!isEcho && localEditPending) {
+          // A newer local edit is still debounce-pending (or in flight to the
+          // host). Rendering this older snapshot would clobber the user's
+          // latest keystrokes and yank the caret. Skip it — the pending edit
+          // will replace the document momentarily (last-writer-wins), and any
+          // genuine external change will arrive again after that settles.
+          updateStatusBar();
+          break;
+        }
         if (!isEcho) {
           isExternalUpdate = true;
           const selStart = textarea.selectionStart;
@@ -219,8 +239,14 @@
           gBtn.disabled = false;
         }
         statusWordCount.textContent = currentGrammarMatches.length + ' grammar issue(s) found';
-        // Re-render preview to apply highlights
-        renderPreview(textarea.value);
+        // Refresh highlights in place. A full renderPreview() here rebuilt the
+        // contenteditable's innerHTML — and because auto grammar checks land
+        // asynchronously (often just as the user resumes typing), that rebuild
+        // randomly moved the caret whenever the markdown→HTML round-trip wasn't
+        // text-identical (smart quotes, `...`→…, a "- " line becoming a list).
+        // Unwrapping and re-wrapping highlight spans never changes text content,
+        // so the caret can be restored to the exact same offset.
+        refreshGrammarHighlights();
         break;
       }
     }
@@ -240,8 +266,11 @@
     renderPreview(text);
     updateStatusBar();
 
+    localEditPending = true;
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
+      localEditPending = false;
+      lastSentEditText = text;
       vscode.postMessage({ type: 'edit', text: text, cursorOffset: textarea.selectionStart });
     }, 50);
   });
@@ -251,9 +280,7 @@
   // ================================================
   let contentEditableDebounce;
 
-  previewContent.addEventListener('input', () => {
-    if (isExternalUpdate) return;
-
+  function syncContentEditable() {
     // Convert HTML back to markdown via Turndown. Guard against Turndown
     // throwing on malformed DOM so a single bad keystroke can't wedge editing.
     let markdown;
@@ -280,12 +307,29 @@
     );
 
     // Debounced send to extension host
+    localEditPending = true;
     clearTimeout(contentEditableDebounce);
     contentEditableDebounce = setTimeout(() => {
+      localEditPending = false;
+      lastSentEditText = markdown;
       vscode.postMessage({ type: 'edit', text: markdown, cursorOffset: previewCaretOffset });
     }, 100);
 
     updateStatusBar();
+  }
+
+  previewContent.addEventListener('input', () => {
+    if (isExternalUpdate || isComposing) return;
+    syncContentEditable();
+  });
+
+  // IME composition: defer all markdown sync until the composition commits.
+  previewContent.addEventListener('compositionstart', () => {
+    isComposing = true;
+  });
+  previewContent.addEventListener('compositionend', () => {
+    isComposing = false;
+    syncContentEditable();
   });
 
   // Handle Tab key - insert tab instead of moving focus
@@ -1095,6 +1139,37 @@
           textNodes.push(n);
         }
       }
+    }
+  }
+
+  /** Unwrap all existing grammar-error spans, leaving text content untouched. */
+  function clearGrammarHighlights() {
+    for (const span of previewContent.querySelectorAll('span.grammar-error')) {
+      const parent = span.parentNode;
+      if (!parent) continue;
+      while (span.firstChild) {
+        parent.insertBefore(span.firstChild, span);
+      }
+      parent.removeChild(span);
+    }
+    // Merge the text nodes the unwrapping left behind so highlight matching
+    // (which searches within single text nodes) sees contiguous text again.
+    previewContent.normalize();
+  }
+
+  /**
+   * Re-apply grammar highlights to the live DOM without re-rendering markdown.
+   * Wrapping/unwrapping spans never changes the element's text content, so the
+   * caret offset round-trips exactly — no cursor movement, unlike a full
+   * renderPreview() which rebuilds innerHTML from (possibly normalized) markdown.
+   */
+  function refreshGrammarHighlights() {
+    const savedCaret = isPreviewMode() ? saveCaretPosition(previewContent) : null;
+    hideGrammarTooltip();
+    clearGrammarHighlights();
+    applyGrammarHighlights();
+    if (savedCaret) {
+      restoreCaretPosition(previewContent, savedCaret);
     }
   }
 

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getNonce } from './utils.js';
+import { getNonce, computeMinimalEdit } from './utils.js';
 import { WebviewToExtensionMessage, GrammarMatch } from './types.js';
 import { FileIndexService } from './wikilink/fileIndexService.js';
 
@@ -92,21 +92,40 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             return;
 
           case 'edit': {
-            applyingEdits++;
-            lastAppliedText = message.text;
             if (message.cursorOffset !== undefined) {
               this.cursorOffsets.set(document.uri.toString(), message.cursorOffset);
             }
+            const currentText = document.getText();
+            if (currentText === message.text) {
+              return;
+            }
+            applyingEdits++;
+            lastAppliedText = message.text;
+            // Apply the smallest ranged edit rather than replacing the whole
+            // document: this keeps undo granular and doesn't disturb cursor or
+            // scroll state in a parallel raw text editor of the same document.
+            const minimal = computeMinimalEdit(currentText, message.text);
             const edit = new vscode.WorkspaceEdit();
             edit.replace(
               document.uri,
-              new vscode.Range(0, 0, document.lineCount, 0),
-              message.text
+              new vscode.Range(
+                document.positionAt(minimal.start),
+                document.positionAt(minimal.end)
+              ),
+              minimal.text
             );
+            let applied = false;
             try {
-              await vscode.workspace.applyEdit(edit);
+              applied = await vscode.workspace.applyEdit(edit);
             } finally {
               applyingEdits--;
+            }
+            if (!applied) {
+              // The edit was rejected (e.g. a concurrent modification). The
+              // webview now shows text that never reached the document — push
+              // the real document state back so the two can't silently diverge.
+              lastAppliedText = null;
+              updateWebview();
             }
             return;
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,38 @@ export function getFileStem(filePath: string): string {
 }
 
 /**
+ * Compute the minimal single-range replacement that turns oldText into newText
+ * by trimming the common prefix and suffix. Returns character offsets into
+ * oldText: replace [start, end) with `text`.
+ *
+ * Used to apply webview edits as a small ranged edit instead of a whole-document
+ * replace — preserving cursor/selection state in any parallel text editor and
+ * keeping the undo stack granular.
+ */
+export function computeMinimalEdit(
+  oldText: string,
+  newText: string
+): { start: number; end: number; text: string } {
+  let start = 0;
+  const maxStart = Math.min(oldText.length, newText.length);
+  while (start < maxStart && oldText.charCodeAt(start) === newText.charCodeAt(start)) {
+    start++;
+  }
+  let oldEnd = oldText.length;
+  let newEnd = newText.length;
+  // The suffix must not overlap the already-matched prefix.
+  while (
+    oldEnd > start &&
+    newEnd > start &&
+    oldText.charCodeAt(oldEnd - 1) === newText.charCodeAt(newEnd - 1)
+  ) {
+    oldEnd--;
+    newEnd--;
+  }
+  return { start, end: oldEnd, text: newText.slice(start, newEnd) };
+}
+
+/**
  * Strip Markdown syntax to produce plain text for LanguageTool.
  * Returns the stripped text and an offset map from stripped positions to original positions.
  */

--- a/tests/computeMinimalEdit.test.mjs
+++ b/tests/computeMinimalEdit.test.mjs
@@ -1,0 +1,94 @@
+// Tests for the minimal-edit computation used to apply webview edits as a
+// small ranged replace instead of a whole-document replace.
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+// Imported from TypeScript source directly — Node strips the types.
+const { computeMinimalEdit } = await import('../src/utils.ts');
+
+/** Apply the computed edit to oldText and return the result. */
+function applyEdit(oldText, edit) {
+  return oldText.slice(0, edit.start) + edit.text + oldText.slice(edit.end);
+}
+
+test('identical text produces an empty edit', () => {
+  const edit = computeMinimalEdit('hello world', 'hello world');
+  assert.strictEqual(edit.start, edit.end);
+  assert.strictEqual(edit.text, '');
+});
+
+test('insertion in the middle', () => {
+  const oldText = 'hello world';
+  const newText = 'hello brave world';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  assert.strictEqual(edit.text, 'brave ');
+});
+
+test('deletion in the middle', () => {
+  const oldText = 'hello brave world';
+  const newText = 'hello world';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  assert.strictEqual(edit.text, '');
+});
+
+test('single character typed at end (common typing case)', () => {
+  const oldText = 'abc';
+  const newText = 'abcd';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  assert.strictEqual(edit.start, 3);
+  assert.strictEqual(edit.end, 3);
+  assert.strictEqual(edit.text, 'd');
+});
+
+test('replacement of a word', () => {
+  const oldText = 'the quick brown fox';
+  const newText = 'the quick red fox';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});
+
+test('empty old text (initial content)', () => {
+  const edit = computeMinimalEdit('', 'new content');
+  assert.strictEqual(applyEdit('', edit), 'new content');
+});
+
+test('empty new text (delete everything)', () => {
+  const edit = computeMinimalEdit('old content', '');
+  assert.strictEqual(applyEdit('old content', edit), '');
+});
+
+test('repeated characters do not over-trim (prefix/suffix overlap)', () => {
+  // Deleting one "a" from "aaaa": prefix matching consumes 3, the suffix loop
+  // must stop at the prefix boundary rather than double-counting.
+  const oldText = 'aaaa';
+  const newText = 'aaa';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});
+
+test('duplicated line insertion round-trips', () => {
+  const oldText = 'line1\nline2\nline3';
+  const newText = 'line1\nline2\nline2\nline3';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});
+
+test('multi-line markdown edit round-trips', () => {
+  const oldText = '# Title\n\nSome paragraph text.\n\n- item one\n- item two\n';
+  const newText = '# Title\n\nSome edited paragraph text!\n\n- item one\n- item two\n';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  // The edit should be confined to the changed paragraph.
+  assert.ok(edit.start >= oldText.indexOf('Some'));
+  assert.ok(edit.end <= oldText.indexOf('\n\n- item'));
+});
+
+test('completely different text', () => {
+  const oldText = 'alpha';
+  const newText = 'omega';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});


### PR DESCRIPTION
## Summary

Fixes the long-standing bug where the cursor randomly moves position or loses focus while live-editing in the WYSIWYG (rendered) view.

### Root cause

Automatic incremental grammar checks (scheduled 1.5s after each document change) complete asynchronously — frequently right as the user resumes typing. The `grammarResults` handler rebuilt the entire contenteditable `innerHTML` via `renderPreview()` and restored the caret by approximate plain-text offset. Whenever the markdown→HTML round-trip was not text-identical (typographer smart quotes, `...` → `…`, a `- ` line becoming a list), the caret landed in the wrong place; if the selection was momentarily outside the preview, it was dropped entirely.

### Changes

**Webview (`media/editor.js`)**
- `grammarResults` now refreshes highlights **in place** (unwrap existing `.grammar-error` spans, re-apply) instead of re-rendering markdown. Text content is unchanged by span wrapping, so the caret offset round-trips exactly — zero cursor movement.
- **Stale-update guard**: a non-echo `update` arriving while a local debounced edit is still pending is skipped rather than clobbering fresh keystrokes; late echoes of our own edit are recognized via `lastSentEditText`.
- **IME composition guard**: markdown sync defers to `compositionend` so IME sequences are not broken mid-composition.

**Extension host (`src/markdownEditorProvider.ts`, `src/utils.ts`)**
- Webview edits are applied as a **minimal ranged edit** (common prefix/suffix trim via new `computeMinimalEdit`) instead of a whole-document replace — keeps undo granular and avoids disturbing cursor/scroll in a parallel raw editor.
- A rejected `applyEdit` now resyncs the webview to real document state instead of silently diverging.

## Testing

- `npm run compile` clean (type-check + esbuild)
- `npm test`: 35/35 pass, including 11 new `computeMinimalEdit` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)