### PR TITLE
fix: code review follow-ups (grammar debounce, notification spam, stale fix offsets, graph webview fixes)

### DIFF
--- a/media/diff.js
+++ b/media/diff.js
@@ -2,7 +2,16 @@
 (function () {
   'use strict';
 
-  var md = window.markdownit();
+  // Match the live editor's markdown-it configuration (media/editor.js) so the
+  // diff view renders line breaks, links, and typography the same way the user
+  // sees them in the editor — otherwise the diff can misrepresent content.
+  // html stays OFF: unlike editor.js this view has no sanitizeHtml() pass, so
+  // enabling raw HTML here would inject file content straight into innerHTML.
+  var md = window.markdownit({
+    linkify: true,
+    typographer: true,
+    breaks: true,
+  });
   var diffContent = document.getElementById('diff-content');
   var dataEl = document.getElementById('diff-data');
 

--- a/media/editor.js
+++ b/media/editor.js
@@ -1198,6 +1198,9 @@
             offset: match.originalOffset,
             length: match.originalLength,
             replacement: replacement,
+            // Lets the host verify the offsets still point at this text —
+            // edits since the check shift offsets and would corrupt the doc.
+            expectedText: match.matchedText,
           });
           hideGrammarTooltip();
         });

--- a/media/editor.js
+++ b/media/editor.js
@@ -33,6 +33,17 @@
   // Track whether the current content update originated from the extension host
   let isExternalUpdate = false;
 
+  // True while an IME composition is in progress in the contenteditable
+  // preview. Serializing/re-rendering mid-composition breaks the IME session
+  // and teleports the caret, so all sync work is deferred to compositionend.
+  let isComposing = false;
+
+  // The markdown most recently posted to the extension host, plus whether a
+  // debounced local edit is still waiting to be posted. Together these let the
+  // update handler recognize late echoes and stale snapshots (see 'update').
+  let lastSentEditText = null;
+  let localEditPending = false;
+
   // Stored frontmatter to preserve during contenteditable round-trips
   let currentFrontmatter = '';
 
@@ -185,7 +196,16 @@
         // text genuinely differs — i.e. a real external change (other editor,
         // git, grammar fix, etc.). This replaces the old isContentEditableUpdate
         // flag, which could get stuck and silently drop external updates.
-        const isEcho = text === textarea.value;
+        const isEcho = text === textarea.value || text === lastSentEditText;
+        if (!isEcho && localEditPending) {
+          // A newer local edit is still debounce-pending (or in flight to the
+          // host). Rendering this older snapshot would clobber the user's
+          // latest keystrokes and yank the caret. Skip it — the pending edit
+          // will replace the document momentarily (last-writer-wins), and any
+          // genuine external change will arrive again after that settles.
+          updateStatusBar();
+          break;
+        }
         if (!isEcho) {
           isExternalUpdate = true;
           const selStart = textarea.selectionStart;
@@ -219,8 +239,14 @@
           gBtn.disabled = false;
         }
         statusWordCount.textContent = currentGrammarMatches.length + ' grammar issue(s) found';
-        // Re-render preview to apply highlights
-        renderPreview(textarea.value);
+        // Refresh highlights in place. A full renderPreview() here rebuilt the
+        // contenteditable's innerHTML — and because auto grammar checks land
+        // asynchronously (often just as the user resumes typing), that rebuild
+        // randomly moved the caret whenever the markdown→HTML round-trip wasn't
+        // text-identical (smart quotes, `...`→…, a "- " line becoming a list).
+        // Unwrapping and re-wrapping highlight spans never changes text content,
+        // so the caret can be restored to the exact same offset.
+        refreshGrammarHighlights();
         break;
       }
     }
@@ -240,8 +266,11 @@
     renderPreview(text);
     updateStatusBar();
 
+    localEditPending = true;
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
+      localEditPending = false;
+      lastSentEditText = text;
       vscode.postMessage({ type: 'edit', text: text, cursorOffset: textarea.selectionStart });
     }, 50);
   });
@@ -251,9 +280,7 @@
   // ================================================
   let contentEditableDebounce;
 
-  previewContent.addEventListener('input', () => {
-    if (isExternalUpdate) return;
-
+  function syncContentEditable() {
     // Convert HTML back to markdown via Turndown. Guard against Turndown
     // throwing on malformed DOM so a single bad keystroke can't wedge editing.
     let markdown;
@@ -280,12 +307,29 @@
     );
 
     // Debounced send to extension host
+    localEditPending = true;
     clearTimeout(contentEditableDebounce);
     contentEditableDebounce = setTimeout(() => {
+      localEditPending = false;
+      lastSentEditText = markdown;
       vscode.postMessage({ type: 'edit', text: markdown, cursorOffset: previewCaretOffset });
     }, 100);
 
     updateStatusBar();
+  }
+
+  previewContent.addEventListener('input', () => {
+    if (isExternalUpdate || isComposing) return;
+    syncContentEditable();
+  });
+
+  // IME composition: defer all markdown sync until the composition commits.
+  previewContent.addEventListener('compositionstart', () => {
+    isComposing = true;
+  });
+  previewContent.addEventListener('compositionend', () => {
+    isComposing = false;
+    syncContentEditable();
   });
 
   // Handle Tab key - insert tab instead of moving focus
@@ -1095,6 +1139,37 @@
           textNodes.push(n);
         }
       }
+    }
+  }
+
+  /** Unwrap all existing grammar-error spans, leaving text content untouched. */
+  function clearGrammarHighlights() {
+    for (const span of previewContent.querySelectorAll('span.grammar-error')) {
+      const parent = span.parentNode;
+      if (!parent) continue;
+      while (span.firstChild) {
+        parent.insertBefore(span.firstChild, span);
+      }
+      parent.removeChild(span);
+    }
+    // Merge the text nodes the unwrapping left behind so highlight matching
+    // (which searches within single text nodes) sees contiguous text again.
+    previewContent.normalize();
+  }
+
+  /**
+   * Re-apply grammar highlights to the live DOM without re-rendering markdown.
+   * Wrapping/unwrapping spans never changes the element's text content, so the
+   * caret offset round-trips exactly — no cursor movement, unlike a full
+   * renderPreview() which rebuilds innerHTML from (possibly normalized) markdown.
+   */
+  function refreshGrammarHighlights() {
+    const savedCaret = isPreviewMode() ? saveCaretPosition(previewContent) : null;
+    hideGrammarTooltip();
+    clearGrammarHighlights();
+    applyGrammarHighlights();
+    if (savedCaret) {
+      restoreCaretPosition(previewContent, savedCaret);
     }
   }
 

--- a/media/fullGraph.js
+++ b/media/fullGraph.js
@@ -168,6 +168,11 @@
   graph.d3Force('charge')?.strength(-300);
   graph.d3Force('link')?.distance(100);
 
+  // Capture force-graph's built-in center force so the "Center force" toggle
+  // can restore it. (window.d3 is not available in this webview — only
+  // force-graph.min.js is loaded — so it can't be recreated from scratch.)
+  const initialCenterForce = graph.d3Force('center') || null;
+
   // Custom force: pull orphan nodes toward the center so they don't drift far away
   function orphanGravity(alpha) {
     const nodes = graph.graphData().nodes;
@@ -214,7 +219,7 @@
   // Tooltip
   function showNodeTooltip(node) {
     const connections = adjacencyMap.get(node.id)?.size || 0;
-    const tags = node.tags && node.tags.length > 0 ? node.tags.join(', ') : 'none';
+    const tags = escapeHtml(node.tags && node.tags.length > 0 ? node.tags.join(', ') : 'none');
     tooltip.innerHTML = `
       <div class="tooltip-title">${escapeHtml(node.label)}</div>
       <div class="tooltip-detail">${escapeHtml(node.folder || 'root')}</div>
@@ -306,7 +311,7 @@
   chargeSlider.addEventListener('input', () => { graph.d3Force('charge')?.strength(parseInt(chargeSlider.value)); graph.d3ReheatSimulation(); });
   distanceSlider.addEventListener('input', () => { graph.d3Force('link')?.distance(parseInt(distanceSlider.value)); graph.d3ReheatSimulation(); });
   centerForce.addEventListener('change', () => {
-    graph.d3Force('center', centerForce.checked ? (window.d3?.forceCenter?.() || null) : null);
+    graph.d3Force('center', centerForce.checked ? initialCenterForce : null);
     graph.d3ReheatSimulation();
   });
   btnFit.addEventListener('click', () => graph.zoomToFit(400, 40));

--- a/media/graph.js
+++ b/media/graph.js
@@ -16,6 +16,12 @@
   function renderFileList(nodes) {
     if (!fileList) return;
 
+    // The whole list is torn down and rebuilt on every update (including
+    // expand/collapse round-trips) — preserve the scroll position so the
+    // view doesn't jump back to the top.
+    const savedScrollTop = fileList.scrollTop;
+    const savedDocScrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : 0;
+
     if (!nodes || nodes.length === 0) {
       fileList.innerHTML = '<div class="empty-msg">No files found</div>';
       return;
@@ -98,6 +104,10 @@
 
     fileList.innerHTML = '';
     fileList.appendChild(fragment);
+    fileList.scrollTop = savedScrollTop;
+    if (document.scrollingElement) {
+      document.scrollingElement.scrollTop = savedDocScrollTop;
+    }
   }
 
   // ================================================

--- a/scripts/copy-vendor.js
+++ b/scripts/copy-vendor.js
@@ -1,42 +1,44 @@
 const fs = require('fs');
 const path = require('path');
 
-const src = path.join(__dirname, '..', 'node_modules', 'markdown-it', 'dist', 'markdown-it.min.js');
 const destDir = path.join(__dirname, '..', 'media');
-const dest = path.join(destDir, 'markdown-it.min.js');
 
 if (!fs.existsSync(destDir)) {
   fs.mkdirSync(destDir, { recursive: true });
 }
 
-if (fs.existsSync(src)) {
-  fs.copyFileSync(src, dest);
-  console.log('Copied markdown-it.min.js to media/');
-} else {
-  console.warn('WARNING: markdown-it.min.js not found at', src);
-  console.warn('Run npm install first.');
+// Vendored webview libraries: copied from node_modules into media/ because
+// webviews load them directly (they are not bundled by esbuild).
+const vendorFiles = [
+  {
+    src: path.join(__dirname, '..', 'node_modules', 'markdown-it', 'dist', 'markdown-it.min.js'),
+    dest: path.join(destDir, 'markdown-it.min.js'),
+  },
+  {
+    src: path.join(__dirname, '..', 'node_modules', 'turndown', 'lib', 'turndown.browser.umd.js'),
+    dest: path.join(destDir, 'turndown.browser.umd.js'),
+  },
+  {
+    src: path.join(__dirname, '..', 'node_modules', 'force-graph', 'dist', 'force-graph.min.js'),
+    dest: path.join(destDir, 'force-graph.min.js'),
+  },
+];
+
+let missing = false;
+
+for (const { src, dest } of vendorFiles) {
+  if (fs.existsSync(src)) {
+    fs.copyFileSync(src, dest);
+    console.log(`Copied ${path.basename(dest)} to media/`);
+  } else {
+    console.error(`ERROR: ${path.basename(dest)} not found at ${src}`);
+    console.error('Run npm install first.');
+    missing = true;
+  }
 }
 
-// Copy turndown
-const tdSrc = path.join(__dirname, '..', 'node_modules', 'turndown', 'lib', 'turndown.browser.umd.js');
-const tdDest = path.join(destDir, 'turndown.browser.umd.js');
-
-if (fs.existsSync(tdSrc)) {
-  fs.copyFileSync(tdSrc, tdDest);
-  console.log('Copied turndown.browser.umd.js to media/');
-} else {
-  console.warn('WARNING: turndown.browser.umd.js not found at', tdSrc);
-  console.warn('Run npm install first.');
-}
-
-// Copy force-graph
-const fgSrc = path.join(__dirname, '..', 'node_modules', 'force-graph', 'dist', 'force-graph.min.js');
-const fgDest = path.join(destDir, 'force-graph.min.js');
-
-if (fs.existsSync(fgSrc)) {
-  fs.copyFileSync(fgSrc, fgDest);
-  console.log('Copied force-graph.min.js to media/');
-} else {
-  console.warn('WARNING: force-graph.min.js not found at', fgSrc);
-  console.warn('Run npm install first.');
+// Fail the build loudly rather than silently packaging a broken extension
+// with missing webview libraries.
+if (missing) {
+  process.exitCode = 1;
 }

--- a/src/diagnosticsProvider.ts
+++ b/src/diagnosticsProvider.ts
@@ -25,7 +25,13 @@ export class LanguageToolDiagnosticsProvider implements vscode.Disposable {
   private diagnosticCollection: vscode.DiagnosticCollection;
   private languageToolService: LanguageToolService;
   private disposables: vscode.Disposable[] = [];
-  private checkTimer: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * Debounce timer per document URI. A single shared timer would let an edit
+   * in document B cancel document A's pending check, leaving A's diagnostics
+   * permanently stale (same pattern as FileIndexService's per-URI debounce).
+   */
+  private checkTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   /** Accumulated grammar matches per document (for incremental merging). */
   private storedMatches = new Map<string, GrammarMatch[]>();
@@ -80,14 +86,16 @@ export class LanguageToolDiagnosticsProvider implements vscode.Disposable {
       return;
     }
 
-    if (this.checkTimer) {
-      clearTimeout(this.checkTimer);
+    const key = document.uri.toString();
+    const existing = this.checkTimers.get(key);
+    if (existing) {
+      clearTimeout(existing);
     }
 
-    this.checkTimer = setTimeout(() => {
-      this.checkTimer = undefined;
+    this.checkTimers.set(key, setTimeout(() => {
+      this.checkTimers.delete(key);
       this.runIncrementalCheck(document);
-    }, this.languageToolService.getCheckDelay());
+    }, this.languageToolService.getCheckDelay()));
   }
 
   /**
@@ -149,7 +157,10 @@ export class LanguageToolDiagnosticsProvider implements vscode.Disposable {
 
     let matches: LanguageToolMatch[];
     try {
-      matches = await this.languageToolService.check(strippedParagraph);
+      // silent: chunk-level failures inside check() must not pop notifications
+      // for auto-checks (check() swallows them internally, so the catch below
+      // alone doesn't prevent the popups).
+      matches = await this.languageToolService.check(strippedParagraph, { silent: true });
     } catch {
       return; // Silently fail for auto-checks
     }
@@ -306,8 +317,9 @@ export class LanguageToolDiagnosticsProvider implements vscode.Disposable {
     this.disposables.forEach((d) => d.dispose());
     this._onGrammarResults.dispose();
     this.diagnosticCollection.clear();
-    if (this.checkTimer) {
-      clearTimeout(this.checkTimer);
+    for (const timer of this.checkTimers.values()) {
+      clearTimeout(timer);
     }
+    this.checkTimers.clear();
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -370,7 +370,12 @@ export function activate(context: vscode.ExtensionContext): void {
   if (languageToolService.isEnabled()) {
     for (const doc of vscode.workspace.textDocuments) {
       if (doc.languageId === 'markdown') {
-        diagnosticsProvider.runCheck(doc);
+        // Fire-and-forget, but never let it become an unhandled rejection —
+        // e.g. positionAt throws if the document is closed while the network
+        // round-trip is still in flight.
+        diagnosticsProvider.runCheck(doc).catch((err) => {
+          console.error('[MarkdownEditor] Startup grammar check failed:', err);
+        });
       }
     }
   }

--- a/src/languageToolService.ts
+++ b/src/languageToolService.ts
@@ -41,8 +41,13 @@ export class LanguageToolService {
   /**
    * Send text to the LanguageTool API for checking.
    * Automatically chunks text to stay within the free API's character limit.
+   *
+   * With `silent: true`, chunk failures are logged but never surface a
+   * notification — required for the automatic incremental checks that run
+   * every checkDelayMs while the user types, which would otherwise spam
+   * warning popups continuously whenever the API is unreachable.
    */
-  public async check(text: string): Promise<LanguageToolMatch[]> {
+  public async check(text: string, options?: { silent?: boolean }): Promise<LanguageToolMatch[]> {
     if (!this.config.enabled || text.trim().length === 0) {
       return [];
     }
@@ -65,7 +70,9 @@ export class LanguageToolService {
         allMatches.push(...matches);
       } catch (error: unknown) {
         console.error(`[Grammar] Chunk ${i + 1} failed:`, error);
-        this.handleCheckError(error);
+        if (!options?.silent) {
+          this.handleCheckError(error);
+        }
         // Continue with remaining chunks even if one fails
       }
 

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getNonce } from './utils.js';
+import { getNonce, computeMinimalEdit } from './utils.js';
 import { WebviewToExtensionMessage, GrammarMatch } from './types.js';
 import { FileIndexService } from './wikilink/fileIndexService.js';
 
@@ -92,21 +92,40 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             return;
 
           case 'edit': {
-            applyingEdits++;
-            lastAppliedText = message.text;
             if (message.cursorOffset !== undefined) {
               this.cursorOffsets.set(document.uri.toString(), message.cursorOffset);
             }
+            const currentText = document.getText();
+            if (currentText === message.text) {
+              return;
+            }
+            applyingEdits++;
+            lastAppliedText = message.text;
+            // Apply the smallest ranged edit rather than replacing the whole
+            // document: this keeps undo granular and doesn't disturb cursor or
+            // scroll state in a parallel raw text editor of the same document.
+            const minimal = computeMinimalEdit(currentText, message.text);
             const edit = new vscode.WorkspaceEdit();
             edit.replace(
               document.uri,
-              new vscode.Range(0, 0, document.lineCount, 0),
-              message.text
+              new vscode.Range(
+                document.positionAt(minimal.start),
+                document.positionAt(minimal.end)
+              ),
+              minimal.text
             );
+            let applied = false;
             try {
-              await vscode.workspace.applyEdit(edit);
+              applied = await vscode.workspace.applyEdit(edit);
             } finally {
               applyingEdits--;
+            }
+            if (!applied) {
+              // The edit was rejected (e.g. a concurrent modification). The
+              // webview now shows text that never reached the document — push
+              // the real document state back so the two can't silently diverge.
+              lastAppliedText = null;
+              updateWebview();
             }
             return;
           }

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -164,9 +164,22 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           }
 
           case 'applyGrammarFix': {
-            applyingEdits++;
             const startPos = document.positionAt(message.offset);
             const endPos = document.positionAt(message.offset + message.length);
+            // Grammar match offsets were computed against the text at check
+            // time. If the document has changed since (edits earlier in the
+            // file shift offsets), applying blindly would replace the wrong
+            // text — verify the range still contains what the check matched.
+            if (
+              message.expectedText !== undefined &&
+              document.getText(new vscode.Range(startPos, endPos)) !== message.expectedText
+            ) {
+              vscode.window.showInformationMessage(
+                'The text has changed since the grammar check — run the check again to apply fixes.'
+              );
+              return;
+            }
+            applyingEdits++;
             const edit = new vscode.WorkspaceEdit();
             edit.replace(document.uri, new vscode.Range(startPos, endPos), message.replacement);
             try {
@@ -201,6 +214,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
     webviewPanel.onDidDispose(() => {
       this.webviewPanels.delete(document.uri.toString());
+      this.cursorOffsets.delete(document.uri.toString());
       if (this.activeDocument === document) {
         this.activeDocument = undefined;
         this._onDidChangeActiveDocument.fire(undefined);

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export type WebviewToExtensionMessage =
   | { type: 'requestGrammarCheck' }
   | { type: 'requestWikilinkSuggestions'; prefix: string }
   | { type: 'openWikilink'; target: string }
-  | { type: 'applyGrammarFix'; offset: number; length: number; replacement: string };
+  | { type: 'applyGrammarFix'; offset: number; length: number; replacement: string; expectedText?: string };
 
 export interface WikilinkSuggestion {
   stem: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,38 @@ export function getFileStem(filePath: string): string {
 }
 
 /**
+ * Compute the minimal single-range replacement that turns oldText into newText
+ * by trimming the common prefix and suffix. Returns character offsets into
+ * oldText: replace [start, end) with `text`.
+ *
+ * Used to apply webview edits as a small ranged edit instead of a whole-document
+ * replace — preserving cursor/selection state in any parallel text editor and
+ * keeping the undo stack granular.
+ */
+export function computeMinimalEdit(
+  oldText: string,
+  newText: string
+): { start: number; end: number; text: string } {
+  let start = 0;
+  const maxStart = Math.min(oldText.length, newText.length);
+  while (start < maxStart && oldText.charCodeAt(start) === newText.charCodeAt(start)) {
+    start++;
+  }
+  let oldEnd = oldText.length;
+  let newEnd = newText.length;
+  // The suffix must not overlap the already-matched prefix.
+  while (
+    oldEnd > start &&
+    newEnd > start &&
+    oldText.charCodeAt(oldEnd - 1) === newText.charCodeAt(newEnd - 1)
+  ) {
+    oldEnd--;
+    newEnd--;
+  }
+  return { start, end: oldEnd, text: newText.slice(start, newEnd) };
+}
+
+/**
  * Strip Markdown syntax to produce plain text for LanguageTool.
  * Returns the stripped text and an offset map from stripped positions to original positions.
  */

--- a/tests/computeMinimalEdit.test.mjs
+++ b/tests/computeMinimalEdit.test.mjs
@@ -1,0 +1,94 @@
+// Tests for the minimal-edit computation used to apply webview edits as a
+// small ranged replace instead of a whole-document replace.
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+// Imported from TypeScript source directly — Node strips the types.
+const { computeMinimalEdit } = await import('../src/utils.ts');
+
+/** Apply the computed edit to oldText and return the result. */
+function applyEdit(oldText, edit) {
+  return oldText.slice(0, edit.start) + edit.text + oldText.slice(edit.end);
+}
+
+test('identical text produces an empty edit', () => {
+  const edit = computeMinimalEdit('hello world', 'hello world');
+  assert.strictEqual(edit.start, edit.end);
+  assert.strictEqual(edit.text, '');
+});
+
+test('insertion in the middle', () => {
+  const oldText = 'hello world';
+  const newText = 'hello brave world';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  assert.strictEqual(edit.text, 'brave ');
+});
+
+test('deletion in the middle', () => {
+  const oldText = 'hello brave world';
+  const newText = 'hello world';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  assert.strictEqual(edit.text, '');
+});
+
+test('single character typed at end (common typing case)', () => {
+  const oldText = 'abc';
+  const newText = 'abcd';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  assert.strictEqual(edit.start, 3);
+  assert.strictEqual(edit.end, 3);
+  assert.strictEqual(edit.text, 'd');
+});
+
+test('replacement of a word', () => {
+  const oldText = 'the quick brown fox';
+  const newText = 'the quick red fox';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});
+
+test('empty old text (initial content)', () => {
+  const edit = computeMinimalEdit('', 'new content');
+  assert.strictEqual(applyEdit('', edit), 'new content');
+});
+
+test('empty new text (delete everything)', () => {
+  const edit = computeMinimalEdit('old content', '');
+  assert.strictEqual(applyEdit('old content', edit), '');
+});
+
+test('repeated characters do not over-trim (prefix/suffix overlap)', () => {
+  // Deleting one "a" from "aaaa": prefix matching consumes 3, the suffix loop
+  // must stop at the prefix boundary rather than double-counting.
+  const oldText = 'aaaa';
+  const newText = 'aaa';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});
+
+test('duplicated line insertion round-trips', () => {
+  const oldText = 'line1\nline2\nline3';
+  const newText = 'line1\nline2\nline2\nline3';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});
+
+test('multi-line markdown edit round-trips', () => {
+  const oldText = '# Title\n\nSome paragraph text.\n\n- item one\n- item two\n';
+  const newText = '# Title\n\nSome edited paragraph text!\n\n- item one\n- item two\n';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+  // The edit should be confined to the changed paragraph.
+  assert.ok(edit.start >= oldText.indexOf('Some'));
+  assert.ok(edit.end <= oldText.indexOf('\n\n- item'));
+});
+
+test('completely different text', () => {
+  const oldText = 'alpha';
+  const newText = 'omega';
+  const edit = computeMinimalEdit(oldText, newText);
+  assert.strictEqual(applyEdit(oldText, edit), newText);
+});


### PR DESCRIPTION
## Summary

Fixes verified findings from a multi-agent code review of the extension host and webviews.

> **Note:** stacked on #37 — merge that first; this PR then shows only its own diff.

### Extension host
- **Per-document grammar debounce** (`diagnosticsProvider.ts`): the incremental-check timer was a single shared field, so editing document B cancelled document A''s pending check, leaving A''s diagnostics permanently stale. Now a `Map` keyed by URI (same pattern as `FileIndexService`).
- **No more notification spam** (`languageToolService.ts`): `check()` swallowed chunk errors internally and popped a warning for each — the incremental checker''s `catch` never saw them, so an unreachable API produced a popup every ~1.5s while typing. Auto-checks now pass `{ silent: true }`; the manual Grammar button still surfaces errors.
- **Stale grammar-fix guard** (`markdownEditorProvider.ts` + `types.ts` + `editor.js`): `applyGrammarFix` applied webview-computed offsets blindly; edits since the check shift offsets and could corrupt unrelated text. The webview now sends `expectedText` and the host verifies the range still matches before replacing.
- **`cursorOffsets` leak**: entry now deleted on panel dispose.
- **Startup unhandled rejection** (`extension.ts`): initial `runCheck` calls now `.catch()` (`positionAt` throws if the doc closes mid network round-trip).

### Webviews
- **fullGraph**: tag text was the only tooltip field interpolated into `innerHTML` unescaped (markdown frontmatter is user/collaborator-controlled) — now escaped. The "Center force" toggle relied on `window.d3`, which doesn''t exist in this webview, so it could disable but never re-enable the force — now captures force-graph''s built-in center force at startup.
- **graph sidebar**: list re-renders (expand/collapse round-trips) preserve scroll position instead of jumping to the top.
- **diff viewer**: markdown-it options aligned with the editor (`breaks`, `linkify`, `typographer`) so diffs render the way the editor does; `html` deliberately stays off — this view has no sanitizer pass.
- **copy-vendor.js**: exits non-zero when a vendor lib is missing, so packaging fails loudly instead of shipping a broken extension.

## Testing
- `npm run compile` clean, `npm test` 35/35 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)