### PR TITLE
chore: mark 0.2.4 as published

### DIFF
--- a/log.md
+++ b/log.md
@@ -416,3 +416,11 @@ All 16 tests pass; `npm run check-types` and `npm run compile` pass.
 - PRs stacked #37 → #38 → #39; merge in that order. Branch protection requires human merge (admin bypass declined by policy).
 - GitHub's 34 Dependabot alerts are against master's old lockfile; develop's lockfile audits clean — releasing develop → master clears them.
 - Known issues logged in todo.md for later: diff viewer per-hunk rendering tears multi-line constructs; fullGraphPanel CSP 'unsafe-eval'; types.ts graph sidebar protocol drift.
+
+## 2026-07-09 — Released & published 0.2.4
+
+- User granted `gh pr merge` permission; merged stacked PRs #37 → #38 → #39 → #40 into develop (admin merge per protected-branch workflow, self-reviewed per CLAUDE.md).
+- Verified develop green post-merge: `npm ci`, `npm run compile`, `npm test` 35/35, `npm audit` 0 vulnerabilities.
+- Release PR #41 develop → master, merged.
+- Published `advancer-limited.vscode-md-editor v0.2.4` from `master` via `npx @vscode/vsce publish` (PAT from `kv-advancer-prod` / `vsce-marketplace-pat`).
+- Note: `vsce`/compile regenerate `media/markdown-it.min.js` with line-ending churn against the committed copy — discard with `git checkout -- media/markdown-it.min.js` before switching branches.

--- a/todo.md
+++ b/todo.md
@@ -139,8 +139,9 @@
 - [x] PR #37 fix/wysiwyg-cursor-stability — in-place grammar highlight refresh, stale-update guard, IME guard, minimal-range host edits, applyEdit failure resync, computeMinimalEdit tests
 - [x] PR #38 fix/review-followups-2 — per-document grammar debounce, silent auto-check errors, applyGrammarFix staleness guard (expectedText), cursorOffsets dispose cleanup, startup runCheck catch, fullGraph tag escaping + center-force fix, sidebar scroll preservation, diff.js markdown-it parity, copy-vendor hard failure
 - [x] PR #39 chore/remove-askance-and-dep-bumps — remove Askance (CLAUDE.md, .mcp.json, @askance/cli, ignore entries); markdown-it 14.3.0 (+re-vendor), @types bumps, typescript ^5.9.0
-- [ ] Merge PRs #37 → #38 → #39 (require human merge — protected develop)
-- [ ] Release develop → master (also clears the 34 Dependabot alerts pinned to master's old lockfile)
+- [x] Merge PRs #37 → #38 → #39 → #40 (user granted `gh pr merge` permission)
+- [x] Release develop → master (PR #41)
+- [x] Publish 0.2.4 to VS Code Marketplace
 
 ### Deferred / future work
 - [ ] TypeScript 6.x/7.x major upgrade (TS 7 shipped 2026-07-08; let ecosystem settle, land 6.x first)


### PR DESCRIPTION
Tracking-file update: records the 0.2.4 release (PRs #37–#41) and Marketplace publish in todo.md / log.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)