### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [0.3.0] - 2026-07-18
+
+### Added
+
+- **Mermaid diagrams** — `\`\`\`mermaid` fences render as live diagrams in the WYSIWYG/split preview (read-only there — edit the source in Raw/Split mode). Rendered SVG is cached so unrelated re-renders don't re-invoke Mermaid, and invalid syntax shows an inline error while keeping the last valid render.
+- **`.mmd`/`.mermaid` editor** — opening a Mermaid source file directly now uses a dedicated forced-split editor (source + live preview), independent of the markdown editor.
+- **Task checklists** — GFM `- [ ] task` / `- [x] task` render as clickable checkboxes in the preview and toggle back to `[ ]`/`[x]` in the markdown source.
+- Diff view and the markdown editor now fully support `.markdown` (not just `.md`) — wikilinks, the file index/graph, and diff commands all recognize it.
+
+### Fixed
+
+- **WYSIWYG cursor jump, for real this time.** The caret position was tracked as a single character offset across the whole preview, which is ambiguous exactly at block boundaries (e.g. right after pressing Enter into a new empty paragraph) — the most common case where earlier fixes (0.2.1, 0.2.4) had already reduced *how often* a caret restore ran, but not the underlying offset math. Replaced with a block-anchored position that removes the ambiguity structurally.
+- A debounced webview edit still in flight to the extension host could be silently overwritten by a stale update racing it.
+- CRLF-line-ending files had their entire body rewritten on the very first keystroke.
+- **"Compare with Saved" was actually comparing against the last commit (HEAD), not the saved file** — now correctly diffs against what's on disk.
+- The diff viewer no longer splits a fenced code block (including a Mermaid diagram) across separate hunks when only an interior line changed — a changed block now always renders as one complete removed block plus one complete added block.
+- A code block containing a shell-style `$(...)` or similar could corrupt neighboring preview text due to a `String.replace()` special-pattern interpretation bug.
+- Grammar-check highlighting could mark (and apply a suggested fix to) the wrong occurrence of a repeated phrase.
+- A clicked grammar-fix suggestion could be silently lost if another edit was in flight at the same moment.
+- Hardened the preview's HTML sanitizer against case variation and embedded control characters in `javascript:`-style URLs, and extended the check beyond `href` to `src`/`xlink:href`/`formaction`/`poster`.
+
 ## [0.2.4] - 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # VS Code MD Editor
 
-A rich Markdown editor extension for Visual Studio Code with split preview, [[wikilinks]], force-directed link graph, version diff, and LanguageTool grammar checking.
+A rich Markdown editor extension for Visual Studio Code with split preview, [[wikilinks]], Mermaid diagrams, task checklists, a force-directed link graph, version diff, and LanguageTool grammar checking.
 
 ## Features
 
 - **WYSIWYG Editing** — Edit markdown in a rich preview with contenteditable, or switch to split view or raw markdown mode.
+- **Mermaid Diagrams** — `\`\`\`mermaid` code fences render as live diagrams in the WYSIWYG/split preview. Diagrams are read-only there (edit the source in Raw/Split mode); a dedicated split-view editor also opens `.mmd`/`.mermaid` files directly, with live rendering and an inline error banner for invalid syntax.
+- **Task Checklists** — GFM `- [ ] task` / `- [x] task` checkboxes render as clickable checkboxes in the preview and toggle directly in the markdown source. Handy for spec-driven workflows (e.g. GitHub Spec Kit `tasks.md` files).
 - **Toolbar** — Quick-access buttons for bold, italic, headings, links, images, code blocks, lists, and blockquotes.
 - **[[Wikilinks]]** — Link between markdown files using `[[filename]]` or `[[filename|display text]]` syntax (Obsidian-compatible) with autocomplete suggestions.
 - **Markdown Links Sidebar** — File list showing all markdown files with their incoming/outgoing links, plus a "Show Graph" button.
 - **Interactive Link Graph** — Full-screen force-directed graph with Obsidian-style controls (filters, display options, force tuning), drag-to-pin, and zoom.
 - **LanguageTool Integration** — Grammar and spelling checking powered by LanguageTool, with inline highlights and quick-fix suggestions. Works with the free API or a Premium account.
-- **Version Diff** — Compare your markdown file against previous git commits in a rendered diff viewer with green/red change highlighting.
-- **Rename Propagation** — Renaming a `.md` file automatically updates all wikilink references across your workspace.
+- **Version Diff** — Compare your markdown file against previous git commits in a rendered diff viewer with green/red change highlighting. Fenced code blocks (including Mermaid diagrams) always diff as a whole block, never split mid-fence.
+- **Rename Propagation** — Renaming a `.md`/`.markdown` file automatically updates all wikilink references across your workspace.
 
 ## Installation
 
@@ -41,6 +43,16 @@ Then press `F5` in VS Code to launch the Extension Development Host.
 3. Type `[[` to get autocomplete suggestions for linking to other markdown files.
 4. Open the **Markdown Links** sidebar to see backlinks and the link graph.
 
+### Mermaid Diagrams
+
+Write a `\`\`\`mermaid` fenced code block and it renders as a live diagram wherever the preview is visible (WYSIWYG or Split). The rendered diagram is read-only — click into Raw or Split mode to edit its source, and the preview updates as you type. Invalid syntax shows an inline error without losing the last valid render.
+
+Opening a `.mmd` or `.mermaid` file directly uses a dedicated split-view editor (source on the left, live diagram on the right) instead of the full markdown editor.
+
+### Task Checklists
+
+`- [ ] some task` and `- [x] done task` lines render as checkboxes in the preview. Click a checkbox to toggle it — the change is written straight back to the markdown source as `[ ]`/`[x]`.
+
 ### Comparing Versions
 
 Compare your markdown files against previous git commits:
@@ -48,10 +60,10 @@ Compare your markdown files against previous git commits:
 - **Command Palette** (`Ctrl+Shift+P` / `Cmd+Shift+P`):
   - **Compare with Previous Version** — Diff against the most recent commit that changed this file.
   - **Compare with Commit...** — Pick from a list of recent commits with hash, message, author, and date.
-  - **Compare with Saved** — Diff your working changes against the last committed version (HEAD).
-- **Right-click** any `.md` file in the Explorer for quick access to diff commands.
+  - **Compare with Saved** — Diff your unsaved working changes against the file as it currently is on disk.
+- **Right-click** any `.md`/`.markdown` file in the Explorer for quick access to diff commands.
 
-The diff opens in a rendered webview panel with green highlighting for additions and red strikethrough for deletions.
+The diff opens in a rendered webview panel with green highlighting for additions and red strikethrough for deletions. Fenced code blocks (including Mermaid diagrams) always diff as a single atomic block, never split across separate hunks.
 
 ## Commands
 
@@ -59,7 +71,7 @@ The diff opens in a rendered webview panel with green highlighting for additions
 | ------- | ----------- |
 | `Markdown Editor: Compare with Previous Version` | Diff against the last commit that changed this file |
 | `Markdown Editor: Compare with Commit...` | Pick a commit from file history and diff against it |
-| `Markdown Editor: Compare with Saved` | Diff working changes against HEAD |
+| `Markdown Editor: Compare with Saved` | Diff working changes against the on-disk saved file |
 | `Markdown Editor: Check Grammar with LanguageTool` | Run grammar and spelling check |
 | `Markdown Editor: Open with VS Code MD Editor` | Open a `.md` file in the custom editor |
 | `Markdown Editor: Show Link Graph` | Focus the Markdown Links sidebar |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
-  "description": "A rich Markdown editor with live preview, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "0.2.4",
+  "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
+  "version": "0.3.0",
   "license": "MIT",
   "publisher": "advancer-limited",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary

Version bump for the release covering PRs #43 (cursor-jump fix), #47 (mermaid WYSIWYG + task checkboxes), #45 (.mmd editor), and #46 (diff fence atomicity + Compare-with-Saved fix + .markdown parity), all already merged to `develop`. Minor bump (0.2.4 → 0.3.0) since new user-facing features were added, not just fixes.

- `package.json`/`package-lock.json` → 0.3.0
- `CHANGELOG.md` — new 0.3.0 entry
- `README.md` — documents Mermaid diagrams, the `.mmd` editor, and task checklists; also **corrects a stale line** that described "Compare with Saved" as diffing against HEAD — that was actually the bug #46 fixed, so the README had been documenting broken behavior as intended.

## Publish-readiness review performed before this bump

- `npx @vscode/vsce package` dry run: clean VSIX contents, no leaked dev files (`.claude/`, `test-server.html`, `src/**/*.ts`, worktree artifacts, etc. all correctly excluded via `.vscodeignore`). Only note: `media/mermaid.min.js` is 3.4 MB uncompressed (flagged by vsce as "large" but not blocking) — necessary for the new diagram-rendering feature; total packaged VSIX is ~1.1 MB compressed.
- `npm audit`: 0 vulnerabilities.
- No leftover `console.log`/`debugger` statements in the new code.
- Both custom editor webviews (`markdownEditorProvider.ts`, `mermaidEditorProvider.ts`) consistently use `retainContextWhenHidden: true`.
- Mermaid initialized with `securityLevel: 'strict'` in both webviews (prevents script execution via diagram label content).

## Verification

`npm run check-types`, `npm run compile`, `npm test` (40/40) all pass.

## Test plan

- [ ] `npx @vscode/vsce package` and install the resulting `.vsix` locally (`code --install-extension vscode-md-editor-0.3.0.vsix`) — spot check the features listed in the CHANGELOG actually work in a real (non-Extension-Development-Host) install
- [ ] Confirm the marketplace listing description/README render correctly after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)