### PR TITLE
feat: mermaid editor overhaul (syntax highlighting, zoom/pan, export, visuals) + 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 serve-test.js
 test-sample.md
 test-server.html
+mmd-test-server.html
 
 # OS files
 .DS_Store

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,6 +23,7 @@ todo.md
 serve-test.js
 test-sample.md
 test-server.html
+mmd-test-server.html
 
 # OS files
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [1.0.0] - 2026-07-19
+
+First stable release.
+
+### Added
+
+- **Mermaid source editor overhaul** — the `.mmd`/`.mermaid` editor now has full syntax highlighting in the source pane (diagram keywords, arrows, node shapes, edge labels, comments, `%%{init}%%` directives), with the offending line highlighted when a diagram fails to parse.
+- **Zoom and pan in the diagram preview** — Ctrl/Cmd+scroll to zoom about the cursor, drag to pan, plus toolbar controls for zoom in/out, 100%, and fit-to-view with a live zoom readout. Your view is preserved as you keep typing, so zooming into part of a large diagram no longer resets on every edit.
+- **Export diagrams as PNG**, with a choice of light or dark background — a light export re-renders the diagram for a white background, so it stays readable when dropped into documents and slides.
+- **Print diagrams / save as PDF** — opens the diagram in your browser, where Print and its "Save as PDF" destination work properly.
+- **Refreshed diagram styling** — softer rounded corners, a flatter and more professional palette, and cleaner typography, with proper light and dark theme support that follows your VS Code theme (including live re-render when you switch themes).
+- An **About** button on editor toolbars showing the product, version, and author.
+
 ## [0.3.0] - 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A rich Markdown editor extension for Visual Studio Code with split preview, [[wi
 ## Features
 
 - **WYSIWYG Editing** — Edit markdown in a rich preview with contenteditable, or switch to split view or raw markdown mode.
-- **Mermaid Diagrams** — `\`\`\`mermaid` code fences render as live diagrams in the WYSIWYG/split preview. Diagrams are read-only there (edit the source in Raw/Split mode); a dedicated split-view editor also opens `.mmd`/`.mermaid` files directly, with live rendering and an inline error banner for invalid syntax.
+- **Mermaid Diagrams** — `\`\`\`mermaid` code fences render as live diagrams in the WYSIWYG/split preview. Diagrams are read-only there (edit the source in Raw/Split mode). A dedicated split-view editor opens `.mmd`/`.mermaid` files directly, with **syntax highlighting**, **error-line marking**, **zoom and pan**, and **PNG / print (Save as PDF) export** — all themed to match VS Code's light or dark theme.
 - **Task Checklists** — GFM `- [ ] task` / `- [x] task` checkboxes render as clickable checkboxes in the preview and toggle directly in the markdown source. Handy for spec-driven workflows (e.g. GitHub Spec Kit `tasks.md` files).
 - **Toolbar** — Quick-access buttons for bold, italic, headings, links, images, code blocks, lists, and blockquotes.
 - **[[Wikilinks]]** — Link between markdown files using `[[filename]]` or `[[filename|display text]]` syntax (Obsidian-compatible) with autocomplete suggestions.
@@ -47,7 +47,15 @@ Then press `F5` in VS Code to launch the Extension Development Host.
 
 Write a `\`\`\`mermaid` fenced code block and it renders as a live diagram wherever the preview is visible (WYSIWYG or Split). The rendered diagram is read-only — click into Raw or Split mode to edit its source, and the preview updates as you type. Invalid syntax shows an inline error without losing the last valid render.
 
-Opening a `.mmd` or `.mermaid` file directly uses a dedicated split-view editor (source on the left, live diagram on the right) instead of the full markdown editor.
+Opening a `.mmd` or `.mermaid` file directly uses a dedicated split-view editor (source on the left, live diagram on the right) with:
+
+- **Syntax highlighting** for Mermaid keywords, arrows, node shapes, edge labels and comments.
+- **Error highlighting** — when a diagram fails to parse, the offending source line is marked alongside the error message.
+- **Zoom and pan** — Ctrl/Cmd+scroll zooms about the pointer, drag to pan, and the toolbar has zoom in/out, 100%, and fit-to-view. Your view is kept as you type, so zooming into part of a large diagram doesn't reset on every edit.
+- **Export as PNG** — choose a light or dark background; the light option re-renders for a white background so it stays readable in documents and slides.
+- **Print / Save as PDF** — opens the diagram in your browser, where the print dialog's "Save as PDF" destination is available.
+
+Diagrams follow your VS Code light or dark theme and re-render automatically when you switch themes.
 
 ### Task Checklists
 

--- a/log.md
+++ b/log.md
@@ -462,3 +462,43 @@ Investigation and code review delegated first to a Fable-model subagent (full di
 - PR #44 is stacked on #43 (not `develop`) for a clean review — merge #43 first, then retarget #44's base to `develop`.
 - PR #45 and #46 are independent of #43/#44 and of each other; can merge in any order.
 - All four branches: `npm run check-types`, `npm run compile`, `npm test` green (#43/#44: 35/35 tests; #46 adds 5 more, 40/40).
+
+## 2026-07-19 — Mermaid editor overhaul, release 1.0.0
+
+Planned by a Fable subagent (full implementation spec), built in the main session, then adversarially reviewed by a second Fable subagent. Three research agents ran in parallel on renderer/licensing questions (see Research notes below).
+
+### Method: regression contract first
+Before touching anything, captured a 14-check behavioral suite against the *existing* `.mmd` editor covering the parts most at risk — echo suppression, CRLF normalization, stale-update dropping, keep-last-good-render, the ready handshake. Baseline: 14/14. Re-run after every subsequent change; still 14/14. This is what makes "didn't break existing functionality" a verified claim rather than an assertion. Reviewer independently confirmed the sync-critical block is byte-identical to develop.
+
+### Features
+- **Syntax highlighting** in the `.mmd` source pane via a transparent-textarea-over-highlighted-`<pre>` overlay. Tokenizer extracted to `media/mermaidSyntax.js` (UMD, following the `turndownTableRules.js` precedent) so it is unit-testable: 26 committed tests covering tokenization, exact source round-trip, and HTML-injection attempts — the output goes to `innerHTML`, so escaping is security-critical, not cosmetic. Escape-then-wrap; class names come from a fixed whitelist so no user input ever reaches an attribute.
+- **Error-line marking** — structured jison `err.hash` first, message-text regex as fallback, banner-only when mermaid reports no line (e.g. UnknownDiagramError).
+- **Zoom/pan** with cursor-anchored Ctrl+wheel zoom, drag-pan, fit/reset/percentage toolbar. Transform deliberately preserved across re-renders — resetting the view on every keystroke made zooming into a large diagram useless.
+- **PNG export** with a light/dark background choice via native QuickPick; a light export *re-renders* rather than rasterizing the on-screen dark diagram (which would give unreadable light-on-white).
+- **Print** — `window.print()` is suppressed in VS Code webviews (sandboxed iframe, no allow-modals) and fails *silently*; the host writes a standalone page and opens it externally where the real print dialog and Save-as-PDF live.
+- **Visual restyle** — themeVariables plus a `<style>` injected *inside* the SVG (so preview, PNG and print all share it): rounded corners, flatter palette, cleaner type. Live re-render on VS Code theme change via a MutationObserver on the body class.
+- **About/brand button** on both editor toolbars; version 1.0.0; `author` field added.
+
+### Empirical findings worth remembering
+- Mermaid emits `width="100%"` and **no** `height` — export dimensions must come from the **viewBox**, not the attributes.
+- Mermaid uses `<foreignObject>` for flowchart labels. This *does* rasterize correctly to canvas in Chromium (verified by writing the PNG out and inspecting it), so no `htmlLabels:false` workaround is needed. Would not hold in Safari — irrelevant, webviews are always Chromium.
+- Rasterizing an inline SVG via a `data:` URL does **not** taint the canvas, so `toDataURL()` works and no CSP change was needed (`img-src data:` was already present). A `blob:` URL *would* have required widening the CSP.
+
+### Review findings fixed (all in the new export path; none touched document sync)
+1. **BUG** dark export from a *light* editor filled the canvas with the light body background → fixed constants per export theme.
+2. **BUG** export/print with a broken source silently fell back to the on-screen SVG in the wrong theme *and reported success* → now renders from `lastGoodSource` (matching what keep-last-good is displaying) and fails loudly if that's unavailable.
+3. **BUG** a diagram wider than 8192px produced a 0-byte PNG with a success toast (`Math.max(1, …)` prevented scaling *down*; oversized canvas → `toDataURL()` returns `"data:,"`) → allow scale < 1 and reject empty output on both sides.
+4. Themed export leaked mermaid's scratch node on failure → same orphan cleanup as the preview path.
+5. Host `exportPng` had no try/catch or payload validation → added.
+6. Print temp files accumulated forever in globalStorageUri → age-based sweep (immediate deletion is unsafe, the browser opens them async).
+7. `vscode-high-contrast-light` was classified as dark → fixed.
+8. Reviewer asked for a *manual* check that `scrollbar-gutter: stable` really equalises content width in both scrolling and non-scrolling states — automated it instead; passes both.
+
+### Research notes (parallel agents) — renderer and licensing decisions
+- **Licensing is the deciding filter**, given the intent to keep commercial options open. The repo already has a CLA, so contributor rights are assigned and relicensing remains possible.
+- **D2** — MPL-2.0 (file-level copyleft; safe to depend on without open-sourcing our code). Official `@terrastruct/d2` WASM build bundles dagre+ELK; TALA is proprietary and excluded. ~8MB, and needs `wasm-unsafe-eval` + `worker-src blob:` added to the CSP. **Recommended** as a future second renderer for architecture diagrams.
+- **PlantUML** — core is GPL. A first-party MIT-flavoured `@plantuml/core` (TeaVM) build now exists and genuinely renders client-side including Graphviz-dependent diagram types, but it is very new and its MIT-ness depends on the maintainer gating GPL paths correctly every release. **Avoid** — the downside is the whole product becoming GPL-encumbered.
+- **3D** — no "Mermaid for 3D" exists. A-Frame (MIT, three.js-based, LLM-fluent) is a *scene* language with no auto-layout, so an LLM must compute coordinates. Recommendation for architecture visualisation is a small custom DSL compiling to vendored three.js, with compiler-side layout so the LLM never emits coordinates. OpenSCAD/X_ITE are GPL — avoid.
+
+### Verification
+66 unit tests, 14 behavioral regression, 23 new-feature Playwright, 7 review-fix Playwright — all passing; `check-types` and `compile` clean.

--- a/media/editor.css
+++ b/media/editor.css
@@ -505,3 +505,34 @@ html, body {
 .grammar-suggestion:hover {
   background: var(--vscode-button-secondaryHoverBackground, #45494e);
 }
+
+/* =============================================
+   Brand / About button
+   ============================================= */
+.brand-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  padding: 2px 6px;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0.85;
+  flex-shrink: 0;
+}
+
+.brand-button:hover {
+  background: var(--vscode-button-secondaryHoverBackground, #505357);
+  opacity: 1;
+}
+
+.brand-button:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder, #007fd4);
+  outline-offset: 1px;
+}
+
+.brand-button svg {
+  display: block;
+}

--- a/media/editor.js
+++ b/media/editor.js
@@ -782,6 +782,11 @@
     });
   }
 
+  // Toolbar: About (brand button)
+  document.getElementById('btn-about')?.addEventListener('click', () => {
+    vscode.postMessage({ type: 'showAbout' });
+  });
+
   // ================================================
   // View toggle
   // ================================================

--- a/media/mermaidEditor.css
+++ b/media/mermaidEditor.css
@@ -10,6 +10,10 @@
   --font-family: var(--vscode-editor-font-family, 'Consolas', 'Courier New', monospace);
   --font-size: var(--vscode-editor-font-size, 14px);
   --preview-font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  --toolbar-bg: var(--vscode-editorGroupHeader-tabsBackground, #252526);
+  --button-bg: var(--vscode-button-secondaryBackground, #3a3d41);
+  --button-fg: var(--vscode-button-secondaryForeground, #ccc);
+  --button-hover-bg: var(--vscode-button-secondaryHoverBackground, #505357);
 }
 
 * {
@@ -36,7 +40,8 @@ html, body {
 }
 
 /* =============================================
-   Editor Pane
+   Editor Pane — transparent textarea over a
+   syntax-highlighted <pre> mirror
    ============================================= */
 .mmd-editor-pane {
   flex: 1;
@@ -45,26 +50,165 @@ html, body {
   min-width: 0;
 }
 
-.mmd-editor-pane textarea {
-  width: 100%;
+.mmd-editor-stack {
+  position: relative;
+  flex: 1;
+  min-width: 0;
   height: 100%;
-  background: var(--editor-bg);
-  color: var(--editor-fg);
-  border: none;
-  outline: none;
-  resize: none;
-  padding: 16px;
-  font-family: var(--font-family);
-  font-size: var(--font-size);
-  line-height: 1.6;
-  tab-size: 4;
-  -moz-tab-size: 4;
-  word-wrap: break-word;
-  white-space: pre-wrap;
 }
 
-.mmd-editor-pane textarea::placeholder {
+/* ---------------------------------------------
+   SHARED TEXT METRICS — every property here
+   affects glyph position. The textarea and the
+   highlight <pre> MUST agree on all of them or
+   the overlay drifts out of alignment. They are
+   deliberately in ONE rule so they cannot be
+   changed for one element and not the other.
+   --------------------------------------------- */
+.mmd-editor-stack textarea,
+.mmd-editor-stack pre.mmd-highlight,
+.mmd-editor-stack pre.mmd-highlight code {
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  font-weight: normal;
+  font-style: normal;
+  /* Ligature/kerning substitution differs between a plain text run and one
+     split across <span>s, which shifts glyphs — disable both. */
+  font-variant-ligatures: none;
+  font-kerning: none;
+  font-feature-settings: normal;
+  line-height: 1.6;
+  letter-spacing: normal;
+  word-spacing: normal;
+  -moz-tab-size: 4;
+  tab-size: 4;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: normal;
+  -webkit-hyphens: none;
+  hyphens: none;
+  text-align: left;
+  text-indent: 0;
+  text-transform: none;
+  text-rendering: auto;
+  direction: ltr;
+  box-sizing: border-box;
+  border: none;
+  margin: 0;
+}
+
+.mmd-editor-stack textarea,
+.mmd-editor-stack pre.mmd-highlight {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 16px;
+  /* Reserve the scrollbar gutter on BOTH elements unconditionally. Without
+     this the textarea (overflow:auto) loses ~14px of content width to its
+     scrollbar while the <pre> (overflow:hidden) does not — different content
+     widths mean different wrap points under pre-wrap, which misaligns
+     everything below the first wrapped line.
+     (Linters flag this as unsupported in Safari; irrelevant here — VS Code
+     webviews are always Chromium/Electron.) */
+  scrollbar-gutter: stable;
+}
+
+.mmd-editor-stack pre.mmd-highlight {
+  z-index: 1;
+  overflow: hidden;
+  pointer-events: none;
+  background: var(--editor-bg);
+  color: var(--editor-fg);
+}
+
+.mmd-editor-stack pre.mmd-highlight code {
+  display: block;
+  padding: 0;
+}
+
+/* Token spans must colour text without perturbing its metrics. */
+.mmd-highlight code span {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.mmd-editor-stack textarea {
+  z-index: 2;
+  color: transparent;
+  background: transparent;
+  caret-color: var(--editor-fg);
+  outline: none;
+  resize: none;
+  overflow: auto;
+}
+
+.mmd-editor-stack textarea::selection {
+  background: var(--vscode-editor-selectionBackground, rgba(38, 79, 120, 0.6));
+  color: transparent;
+}
+
+/* ::placeholder colour is independent of the element's transparent color. */
+.mmd-editor-stack textarea::placeholder {
   color: var(--vscode-input-placeholderForeground, #888);
+}
+
+/* =============================================
+   Syntax highlighting token colours
+   (VS Code exposes no token colours as CSS vars,
+   so these mirror Dark+ / Light+ conventions)
+   ============================================= */
+.tok-comment   { color: #6A9955; }
+.tok-directive { color: #C586C0; }
+.tok-string    { color: #CE9178; }
+.tok-diagram   { color: #569CD6; font-weight: 600; }
+.tok-keyword   { color: #C586C0; }
+.tok-direction { color: #4EC9B0; }
+.tok-arrow     { color: #569CD6; }
+.tok-bracket   { color: #FFD700; }
+.tok-label     { color: #CE9178; }
+.tok-number    { color: #B5CEA8; }
+
+body.vscode-light .tok-comment   { color: #008000; }
+body.vscode-light .tok-directive { color: #AF00DB; }
+body.vscode-light .tok-string    { color: #A31515; }
+body.vscode-light .tok-diagram   { color: #0000FF; }
+body.vscode-light .tok-keyword   { color: #AF00DB; }
+body.vscode-light .tok-direction { color: #267F99; }
+body.vscode-light .tok-arrow     { color: #0000FF; }
+body.vscode-light .tok-bracket   { color: #0431FA; }
+body.vscode-light .tok-label     { color: #A31515; }
+body.vscode-light .tok-number    { color: #098658; }
+
+body.vscode-high-contrast .mmd-highlight code span { color: var(--editor-fg); }
+body.vscode-high-contrast .tok-comment { color: #7CA668; }
+
+/* =============================================
+   Error line marking in the source pane
+   ============================================= */
+.mmd-line.mmd-error-line {
+  background: rgba(190, 17, 0, 0.18);
+}
+
+body.vscode-light .mmd-line.mmd-error-line {
+  background: rgba(190, 17, 0, 0.10);
+}
+
+/* Full-width bar behind the offending line, with a gutter marker. Positioned
+   in the <pre>'s content coordinates so it scrolls with the text. */
+.mmd-error-line-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: rgba(190, 17, 0, 0.10);
+  border-left: 3px solid var(--vscode-inputValidation-errorBorder, #be1100);
 }
 
 /* =============================================
@@ -83,25 +227,109 @@ html, body {
 }
 
 /* =============================================
-   Preview Pane
+   Preview Pane — toolbar + zoom/pan viewport
    ============================================= */
 .mmd-preview-pane {
   flex: 1;
-  overflow: auto;
-  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   min-width: 0;
 }
 
-.mmd-preview-pane svg {
-  max-width: 100%;
-  height: auto;
+.mmd-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  background: var(--toolbar-bg);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.mmd-toolbar button {
+  background: var(--button-bg);
+  color: var(--button-fg);
+  border: none;
+  border-radius: 3px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-family: var(--preview-font-family);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.mmd-toolbar button:hover:not(:disabled) {
+  background: var(--button-hover-bg);
+}
+
+.mmd-toolbar button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.mmd-toolbar button:focus-visible {
+  outline: 1px solid var(--focus-border);
+  outline-offset: 1px;
+}
+
+.mmd-zoom-readout {
+  min-width: 48px;
+  text-align: center;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--vscode-descriptionForeground, #999);
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.mmd-toolbar-separator {
+  width: 1px;
+  height: 16px;
+  background: var(--border-color);
+  margin: 0 4px;
+}
+
+.mmd-toolbar-spacer {
+  flex: 1;
+}
+
+/* The viewport clips; the inner canvas is what gets transformed. */
+.mmd-viewport {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  cursor: grab;
+}
+
+.mmd-viewport.panning {
+  cursor: grabbing;
+}
+
+.mmd-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+  will-change: transform;
+}
+
+/* NOTE: deliberately NOT `max-width: 100%` — that would rescale the diagram
+   against the pane on every resize and fight the zoom transform. Size is
+   normalized from the SVG's viewBox in mermaidEditor.js instead. */
+.mmd-canvas svg {
+  display: block;
 }
 
 /* =============================================
-   Error banner
+   Error banner — outside the viewport, so it
+   never zooms or pans with the diagram
    ============================================= */
 .mmd-error {
-  margin-top: 12px;
+  flex-shrink: 0;
+  margin: 8px;
   padding: 8px 12px;
   border: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
   background: var(--vscode-inputValidation-errorBackground, rgba(190, 17, 0, 0.15));
@@ -110,4 +338,37 @@ html, body {
   font-size: 12px;
   white-space: pre-wrap;
   border-radius: 3px;
+  max-height: 30%;
+  overflow: auto;
+}
+
+/* =============================================
+   Brand / About button
+   ============================================= */
+.brand-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  padding: 2px 6px;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0.85;
+  flex-shrink: 0;
+}
+
+.brand-button:hover {
+  background: var(--button-hover-bg);
+  opacity: 1;
+}
+
+.brand-button:focus-visible {
+  outline: 1px solid var(--focus-border);
+  outline-offset: 1px;
+}
+
+.brand-button svg {
+  display: block;
 }

--- a/media/mermaidEditor.js
+++ b/media/mermaidEditor.js
@@ -6,8 +6,17 @@
   const textarea = /** @type {HTMLTextAreaElement} */ (
     document.getElementById('mmd-input')
   );
+  const highlightPre = /** @type {HTMLPreElement} */ (
+    document.getElementById('mmd-highlight')
+  );
+  const highlightCode = /** @type {HTMLElement} */ (
+    document.getElementById('mmd-highlight-code')
+  );
   const preview = /** @type {HTMLDivElement} */ (
     document.getElementById('mmd-preview')
+  );
+  const viewport = /** @type {HTMLDivElement} */ (
+    document.getElementById('mmd-viewport')
   );
   const errorEl = /** @type {HTMLDivElement} */ (
     document.getElementById('mmd-error')
@@ -18,13 +27,104 @@
   const divider = /** @type {HTMLDivElement} */ (
     document.getElementById('mmd-divider')
   );
+  const zoomReadout = /** @type {HTMLSpanElement} */ (
+    document.getElementById('mmd-zoom-readout')
+  );
+  const btnExportPng = /** @type {HTMLButtonElement} */ (
+    document.getElementById('mmd-export-png')
+  );
+  const btnPrint = /** @type {HTMLButtonElement} */ (
+    document.getElementById('mmd-print')
+  );
+
+  // @ts-ignore - MermaidSyntax loaded globally from mermaidSyntax.js
+  const syntax = MermaidSyntax;
+
+  // ================================================
+  // Diagram theming
+  // ================================================
+  // Mermaid's stock themes look distinctly "default-y" — squared corners,
+  // heavy saturated fills, browser-default fonts. These overrides aim for a
+  // flatter, more professional look that also sits naturally inside VS Code.
+  const DIAGRAM_FONT =
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", "Helvetica Neue", Arial, sans-serif';
+
+  const THEME_VARIABLES = {
+    dark: {
+      background: 'transparent',
+      primaryColor: '#2d333b',
+      primaryBorderColor: '#6e7681',
+      primaryTextColor: '#e6edf3',
+      secondaryColor: '#31363f',
+      tertiaryColor: '#22272e',
+      lineColor: '#8b949e',
+      textColor: '#e6edf3',
+      mainBkg: '#2d333b',
+      nodeBorder: '#6e7681',
+      clusterBkg: 'rgba(110, 118, 129, 0.10)',
+      clusterBorder: '#484f58',
+      edgeLabelBackground: '#22272e',
+      titleColor: '#e6edf3',
+    },
+    light: {
+      background: 'transparent',
+      primaryColor: '#f6f8fa',
+      primaryBorderColor: '#9aa5b1',
+      primaryTextColor: '#1f2328',
+      secondaryColor: '#eef1f4',
+      tertiaryColor: '#ffffff',
+      lineColor: '#6e7781',
+      textColor: '#1f2328',
+      mainBkg: '#f6f8fa',
+      nodeBorder: '#9aa5b1',
+      clusterBkg: 'rgba(110, 119, 129, 0.06)',
+      clusterBorder: '#d0d7de',
+      edgeLabelBackground: '#ffffff',
+      titleColor: '#1f2328',
+    },
+  };
+
+  /** 'light' | 'dark' for the current VS Code colour theme. */
+  function currentThemeKind() {
+    return document.body.classList.contains('vscode-light') ? 'light' : 'dark';
+  }
+
+  function mermaidConfigFor(kind) {
+    const vars = Object.assign({ fontFamily: DIAGRAM_FONT, fontSize: '14px' }, THEME_VARIABLES[kind]);
+    return {
+      startOnLoad: false,
+      securityLevel: 'strict',
+      theme: 'base',
+      fontFamily: DIAGRAM_FONT,
+      themeVariables: vars,
+      flowchart: { curve: 'basis', htmlLabels: true, padding: 12, useMaxWidth: false },
+      sequence: { useMaxWidth: false },
+      class: { useMaxWidth: false },
+    };
+  }
+
+  /**
+   * Refinements mermaid's theme variables can't express (it has no
+   * border-radius variable). Injected as a <style> INSIDE the SVG so it
+   * travels with the element — the preview, the PNG rasterization and the
+   * printed page all pick it up from the same place.
+   */
+  const DIAGRAM_STYLE_CSS =
+    '.node rect,.node polygon,.node path{rx:4px;ry:4px;}' +
+    '.cluster rect{rx:6px;ry:6px;}' +
+    '.node rect,.node circle,.node ellipse,.node polygon,.node path{stroke-width:1.25px;}' +
+    '.edgePath .path,.flowchart-link{stroke-width:1.5px;}' +
+    '.edgeLabel{font-size:12px;}' +
+    'text,.nodeLabel,.edgeLabel,.label{font-family:' + DIAGRAM_FONT + ';}';
+
+  function applyDiagramStyling(svgEl) {
+    const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+    style.textContent = DIAGRAM_STYLE_CSS;
+    svgEl.insertBefore(style, svgEl.firstChild);
+  }
 
   // @ts-ignore - mermaid loaded globally from mermaid.min.js
-  mermaid.initialize({
-    startOnLoad: false,
-    securityLevel: 'strict',
-    theme: document.body.classList.contains('vscode-light') ? 'default' : 'dark',
-  });
+  mermaid.initialize(mermaidConfigFor(currentThemeKind()));
 
   // Track whether the current textarea update originated from the extension
   // host (an 'update' message), so the 'input' handler doesn't treat the
@@ -58,10 +158,88 @@
     return text.replace(/\r\n/g, '\n');
   }
 
+  // ================================================
+  // Syntax highlighting overlay
+  // ================================================
+  // The <pre> mirror is purely presentational: it is never edited, never
+  // focused, and never written back to. The textarea remains the single
+  // editing surface and the source of truth for all document sync.
+
+  /** 1-based line number mermaid last reported an error on, or null. */
+  let currentErrorLine = null;
+  let errorBar = null;
+
+  function getErrorBar() {
+    if (!errorBar) {
+      errorBar = document.createElement('div');
+      errorBar.className = 'mmd-error-line-bar';
+      errorBar.hidden = true;
+      highlightPre.appendChild(errorBar);
+    }
+    return errorBar;
+  }
+
+  /**
+   * Re-apply the error-line marking to the freshly rebuilt highlight DOM.
+   * Must run after every updateHighlight(), since innerHTML replacement
+   * destroys the previous marker and bar position.
+   */
+  function reapplyErrorLine() {
+    const bar = getErrorBar();
+    if (currentErrorLine === null) {
+      bar.hidden = true;
+      return;
+    }
+    const span = highlightCode.querySelector(
+      '.mmd-line[data-line="' + currentErrorLine + '"]'
+    );
+    if (!span) {
+      bar.hidden = true;
+      return;
+    }
+    span.classList.add('mmd-error-line');
+    // An inline span can fragment across visual lines when wrapped, so use
+    // the union rect rather than offsetTop, and convert to the <pre>'s
+    // content coordinates so the bar scrolls with the text.
+    const r = span.getBoundingClientRect();
+    const p = highlightPre.getBoundingClientRect();
+    bar.style.top = (r.top - p.top + highlightPre.scrollTop) + 'px';
+    bar.style.height = r.height + 'px';
+    bar.hidden = false;
+  }
+
+  /**
+   * Rebuild the highlight overlay from the given source.
+   * Runs synchronously on every keystroke — a per-line regex pass plus one
+   * innerHTML assignment is ~1-3ms for a typical diagram, and debouncing it
+   * would leave the (transparent) textarea text visibly unpainted while
+   * typing.
+   */
+  function updateHighlight(text) {
+    highlightCode.innerHTML = syntax.buildHighlightHtml(text);
+    reapplyErrorLine();
+  }
+
+  // Keep the mirror's scroll position locked to the textarea's. Both writes
+  // target an overflow:hidden element, so there's no read-after-write layout
+  // cycle to thrash; doing this in rAF would instead show the colour layer
+  // lagging a frame behind the text while scrolling.
+  textarea.addEventListener('scroll', () => {
+    highlightPre.scrollTop = textarea.scrollTop;
+    highlightPre.scrollLeft = textarea.scrollLeft;
+  });
+
+  // ================================================
+  // Message handling from the extension host
+  // ================================================
   window.addEventListener('message', (event) => {
     const message = event.data;
     if (message.type === 'editAck') {
       editsInFlight = Math.max(0, editsInFlight - 1);
+      return;
+    }
+    if (message.type === 'exportPngTheme') {
+      exportPng(message.theme === 'light' ? 'light' : 'dark');
       return;
     }
     if (message.type === 'update') {
@@ -84,6 +262,10 @@
       textarea.selectionStart = Math.min(selStart, text.length);
       textarea.selectionEnd = Math.min(selEnd, text.length);
       isExternalUpdate = false;
+      // A programmatic value assignment fires no 'input' event, so the
+      // overlay must be refreshed explicitly here.
+      updateHighlight(text);
+      highlightPre.scrollTop = textarea.scrollTop;
       renderDiagram(text);
     }
   });
@@ -93,6 +275,8 @@
       return;
     }
     const text = textarea.value;
+
+    updateHighlight(text);
 
     clearTimeout(renderDebounce);
     renderDebounce = setTimeout(() => renderDiagram(text), 300);
@@ -107,12 +291,40 @@
     }, 150);
   });
 
+  // ================================================
+  // Diagram rendering
+  // ================================================
+
+  /**
+   * Give the SVG intrinsic pixel dimensions. Mermaid emits a viewBox plus
+   * width="100%" (and a max-width style) so it scales to its container —
+   * which would fight the zoom transform, so pin it to real pixels instead.
+   */
+  function normalizeSvg(svg) {
+    const vb = svg.viewBox && svg.viewBox.baseVal;
+    const rect = svg.getBoundingClientRect();
+    const w = (vb && vb.width) || rect.width;
+    const h = (vb && vb.height) || rect.height;
+    svg.setAttribute('width', String(w));
+    svg.setAttribute('height', String(h));
+    svg.style.maxWidth = 'none';
+    return { w, h };
+  }
+
+  function setExportButtonsEnabled(enabled) {
+    if (btnExportPng) btnExportPng.disabled = !enabled;
+    if (btnPrint) btnPrint.disabled = !enabled;
+  }
+
   /** @param {string} source */
   async function renderDiagram(source) {
     const seq = ++renderSeq;
     if (!source.trim()) {
       preview.innerHTML = '';
       errorEl.hidden = true;
+      currentErrorLine = null;
+      reapplyErrorLine();
+      setExportButtonsEnabled(false);
       return;
     }
     const diagramId = 'mmd-diagram-' + seq;
@@ -126,8 +338,27 @@
         // drop the stale result instead of flashing an old diagram back in.
         return;
       }
+      // Note: only preview's *contents* are replaced. The #mmd-preview
+      // element itself survives, which is what preserves the zoom/pan
+      // transform on it across re-renders.
       preview.innerHTML = svg;
       errorEl.hidden = true;
+      currentErrorLine = null;
+      reapplyErrorLine();
+
+      const svgEl = preview.querySelector('svg');
+      if (svgEl) {
+        applyDiagramStyling(svgEl);
+        const size = normalizeSvg(svgEl);
+        setExportButtonsEnabled(true);
+        // Auto-fit only on the first successful render of this panel's
+        // lifetime. Re-fitting on later renders would yank the view out from
+        // under a user who has zoomed in and kept typing.
+        if (!hasAutoFitted) {
+          fitToView(size);
+          hasAutoFitted = true;
+        }
+      }
     } catch (err) {
       if (seq !== renderSeq) {
         return;
@@ -141,11 +372,282 @@
         orphan.remove();
       }
       // Keep-last-good-render: leave `preview` untouched (it still shows the
-      // last valid diagram, if any) and just surface the error banner.
+      // last valid diagram, if any) and just surface the error banner plus
+      // the offending source line.
       errorEl.textContent = String((err && err.message) || err);
       errorEl.hidden = false;
+      currentErrorLine = syntax.extractErrorLine(err, source);
+      reapplyErrorLine();
     }
   }
+
+  // ================================================
+  // Zoom & pan
+  // ================================================
+  const ZOOM_MIN = 0.1;
+  const ZOOM_MAX = 8;
+  const ZOOM_STEP = 1.1;
+  const FIT_PADDING = 24;
+
+  let zoom = 1;
+  let panX = 0;
+  let panY = 0;
+  let hasAutoFitted = false;
+
+  function applyTransform() {
+    preview.style.transform =
+      'translate(' + panX + 'px, ' + panY + 'px) scale(' + zoom + ')';
+    if (zoomReadout) {
+      zoomReadout.textContent = Math.round(zoom * 100) + '%';
+    }
+  }
+
+  function clampZoom(z) {
+    return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
+  }
+
+  /**
+   * Zoom about a fixed viewport point. With transform-origin at 0 0 the
+   * content point under viewport point c is u = (c - pan) / zoom; holding u
+   * fixed across a zoom change gives pan' = c - u * zoom'.
+   */
+  function zoomAt(cx, cy, factor) {
+    const next = clampZoom(zoom * factor);
+    panX = cx - ((cx - panX) / zoom) * next;
+    panY = cy - ((cy - panY) / zoom) * next;
+    zoom = next;
+    applyTransform();
+  }
+
+  function zoomAtCenter(factor) {
+    zoomAt(viewport.clientWidth / 2, viewport.clientHeight / 2, factor);
+  }
+
+  function fitToView(size) {
+    const svg = preview.querySelector('svg');
+    if (!svg) return;
+    let w = size && size.w;
+    let h = size && size.h;
+    if (!w || !h) {
+      const vb = svg.viewBox && svg.viewBox.baseVal;
+      w = (vb && vb.width) || svg.getBoundingClientRect().width;
+      h = (vb && vb.height) || svg.getBoundingClientRect().height;
+    }
+    const vw = viewport.clientWidth;
+    const vh = viewport.clientHeight;
+    if (!w || !h || !vw || !vh) return;
+    zoom = clampZoom(Math.min((vw - 2 * FIT_PADDING) / w, (vh - 2 * FIT_PADDING) / h));
+    panX = (vw - w * zoom) / 2;
+    panY = (vh - h * zoom) / 2;
+    applyTransform();
+  }
+
+  function resetZoom() {
+    zoom = 1;
+    const svg = preview.querySelector('svg');
+    if (svg) {
+      const vb = svg.viewBox && svg.viewBox.baseVal;
+      const w = (vb && vb.width) || svg.getBoundingClientRect().width;
+      const h = (vb && vb.height) || svg.getBoundingClientRect().height;
+      panX = Math.max(0, (viewport.clientWidth - w) / 2);
+      panY = Math.max(0, (viewport.clientHeight - h) / 2);
+    } else {
+      panX = 0;
+      panY = 0;
+    }
+    applyTransform();
+  }
+
+  // Ctrl/Cmd+wheel zooms (this also covers macOS trackpad pinch, which
+  // Chromium reports as ctrl+wheel); plain wheel pans, since the viewport
+  // has no native scrolling of its own — the transform IS the scroll model.
+  viewport.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const r = viewport.getBoundingClientRect();
+    if (e.ctrlKey || e.metaKey) {
+      zoomAt(e.clientX - r.left, e.clientY - r.top, e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP);
+    } else {
+      panX -= e.deltaX;
+      panY -= e.deltaY;
+      applyTransform();
+    }
+  }, { passive: false });
+
+  // Drag-to-pan. Uses its own flag and a distinct mousedown target from the
+  // divider's drag, so the two document-level listeners can never both act.
+  let isPanning = false;
+  let panStartX = 0;
+  let panStartY = 0;
+  let panOrigX = 0;
+  let panOrigY = 0;
+
+  viewport.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    isPanning = true;
+    viewport.classList.add('panning');
+    panStartX = e.clientX;
+    panStartY = e.clientY;
+    panOrigX = panX;
+    panOrigY = panY;
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', (e) => {
+    if (!isPanning) return;
+    panX = panOrigX + (e.clientX - panStartX);
+    panY = panOrigY + (e.clientY - panStartY);
+    applyTransform();
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (isPanning) {
+      isPanning = false;
+      viewport.classList.remove('panning');
+    }
+  });
+
+  document.getElementById('mmd-zoom-in')?.addEventListener('click', () => zoomAtCenter(ZOOM_STEP));
+  document.getElementById('mmd-zoom-out')?.addEventListener('click', () => zoomAtCenter(1 / ZOOM_STEP));
+  document.getElementById('mmd-zoom-reset')?.addEventListener('click', resetZoom);
+  document.getElementById('mmd-zoom-fit')?.addEventListener('click', () => fitToView());
+  zoomReadout?.addEventListener('click', resetZoom);
+  document.getElementById('btn-about')?.addEventListener('click', () => vscode.postMessage({ type: 'showAbout' }));
+
+  // ================================================
+  // Export: PNG and print
+  // ================================================
+  /** Separate from renderSeq — see renderThemedSvg. */
+  let exportSeq = 0;
+
+  /**
+   * Render the current source off-screen in a specific theme, for export and
+   * print. Uses an `%%{init}%%` directive rather than re-initializing mermaid
+   * globally, so it can't race the live preview's own render. (If the user's
+   * source already sets a theme explicitly, theirs wins — respecting an
+   * explicit authored choice is the right call.)
+   *
+   * @param {'light'|'dark'} kind
+   * @returns {Promise<SVGSVGElement|null>}
+   */
+  async function renderThemedSvg(kind) {
+    const source = textarea.value;
+    if (!source.trim()) return null;
+    const directive = '%%{init: ' + JSON.stringify({
+      theme: 'base',
+      themeVariables: Object.assign(
+        { fontFamily: DIAGRAM_FONT, fontSize: '14px' },
+        THEME_VARIABLES[kind]
+      ),
+    }) + '}%%\n';
+    try {
+      // Deliberately NOT renderSeq — bumping that would make an in-flight
+      // preview render see itself as superseded and silently bail.
+      // @ts-ignore - mermaid global
+      const { svg } = await mermaid.render('mmd-export-' + (++exportSeq), directive + source);
+      const holder = document.createElement('div');
+      holder.innerHTML = svg;
+      const el = /** @type {SVGSVGElement|null} */ (holder.querySelector('svg'));
+      if (el) applyDiagramStyling(el);
+      return el;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /**
+   * Serialize a diagram SVG at its intrinsic size, independent of the current
+   * zoom/pan (the transform lives on the wrapper, not the SVG itself).
+   * @param {SVGSVGElement} [svgOverride] use this SVG instead of the previewed one
+   */
+  function serializeSvg(svgOverride) {
+    const svg = svgOverride || preview.querySelector('svg');
+    if (!svg) return null;
+    const clone = /** @type {SVGSVGElement} */ (svg.cloneNode(true));
+    const vb = svg.viewBox && svg.viewBox.baseVal;
+    const rect = svg.getBoundingClientRect();
+    const w = (vb && vb.width) || parseFloat(svg.getAttribute('width')) || rect.width / zoom;
+    const h = (vb && vb.height) || parseFloat(svg.getAttribute('height')) || rect.height / zoom;
+    clone.setAttribute('width', String(w));
+    clone.setAttribute('height', String(h));
+    if (!clone.getAttribute('viewBox')) {
+      clone.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+    }
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.style.maxWidth = 'none';
+    return { text: new XMLSerializer().serializeToString(clone), w, h };
+  }
+
+  /**
+   * @param {'light'|'dark'} themeKind background/diagram theme for the image
+   */
+  async function exportPng(themeKind) {
+    // Re-render in the chosen theme rather than rasterizing what's on screen,
+    // so a light-background export from a dark editor gets dark-on-light text
+    // rather than an unreadable light-on-light image.
+    const themed = themeKind === currentThemeKind() ? null : await renderThemedSvg(themeKind);
+    const serialized = serializeSvg(themed || undefined);
+    if (!serialized) return;
+    const { text, w, h } = serialized;
+    try {
+      // A data: URL keeps the canvas untainted and is already permitted by
+      // the webview CSP's `img-src ... data:` (a blob: URL would need the
+      // CSP widened).
+      const url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(text);
+      const img = new Image();
+      await new Promise((resolve, reject) => {
+        img.onload = resolve;
+        img.onerror = () => reject(new Error('Failed to rasterize the diagram'));
+        img.src = url;
+      });
+
+      // 2x for crispness, clamped so a huge diagram can't blow past
+      // Chromium's canvas limits.
+      const scale = Math.max(1, Math.min(2, 8192 / Math.max(w, h)));
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.max(1, Math.ceil(w * scale));
+      canvas.height = Math.max(1, Math.ceil(h * scale));
+      const ctx = canvas.getContext('2d');
+      // Fill with the editor background rather than leaving it transparent:
+      // mermaid picks its theme from the VS Code theme, so a dark-theme
+      // diagram has light text that would be invisible on white.
+      ctx.fillStyle = themeKind === 'light'
+        ? '#ffffff'
+        : (getComputedStyle(document.body).backgroundColor || '#1e1e1e');
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      const base64 = canvas.toDataURL('image/png').split(',')[1];
+      vscode.postMessage({ type: 'exportPng', base64: base64 });
+    } catch (err) {
+      vscode.postMessage({
+        type: 'exportError',
+        message: String((err && err.message) || err),
+      });
+    }
+  }
+
+  // The image theme is picked in a native VS Code QuickPick on the host side,
+  // which replies with 'exportPngTheme'.
+  btnExportPng?.addEventListener('click', () => {
+    if (!preview.querySelector('svg')) return;
+    vscode.postMessage({ type: 'requestPngExport' });
+  });
+
+  // window.print() does NOT work inside a VS Code webview — they're
+  // sandboxed iframes without allow-modals, so the print dialog is
+  // suppressed silently. Instead the host writes a standalone HTML file and
+  // opens it in the real browser, where Print (and its "Save as PDF"
+  // destination) works properly.
+  //
+  // Printing always uses the light theme: a dark-theme diagram prints as
+  // light-on-white (i.e. invisible) or wastes a page of toner.
+  btnPrint?.addEventListener('click', async () => {
+    if (!preview.querySelector('svg')) return;
+    const themed = currentThemeKind() === 'light' ? null : await renderThemedSvg('light');
+    const serialized = serializeSvg(themed || undefined);
+    if (!serialized) return;
+    vscode.postMessage({ type: 'print', svg: serialized.text });
+  });
 
   // ================================================
   // Draggable divider for pane resizing
@@ -181,6 +683,21 @@
     }
   });
 
+  // VS Code swaps body classes (vscode-light/vscode-dark) when the colour
+  // theme changes. Mermaid bakes its colours into the rendered SVG, so the
+  // diagram has to be re-rendered to follow the new theme.
+  let themeKind = currentThemeKind();
+  new MutationObserver(() => {
+    const next = currentThemeKind();
+    if (next === themeKind) return;
+    themeKind = next;
+    // @ts-ignore - mermaid global
+    mermaid.initialize(mermaidConfigFor(next));
+    renderDiagram(textarea.value);
+  }).observe(document.body, { attributes: true, attributeFilter: ['class'] });
+
+  setExportButtonsEnabled(false);
+  applyTransform();
   vscode.postMessage({ type: 'ready' });
   // Initial render happens when the first 'update' message arrives.
 })();

--- a/media/mermaidEditor.js
+++ b/media/mermaidEditor.js
@@ -84,9 +84,19 @@
     },
   };
 
+  /** Canvas fill for each export theme. Must not be sampled from the live
+   *  body background — exporting "dark" from a light editor would then fill
+   *  with the light background and produce light-on-light output. */
+  const EXPORT_BACKGROUND = { light: '#ffffff', dark: '#1e1e1e' };
+
   /** 'light' | 'dark' for the current VS Code colour theme. */
   function currentThemeKind() {
-    return document.body.classList.contains('vscode-light') ? 'light' : 'dark';
+    const cl = document.body.classList;
+    // vscode-high-contrast-light also carries vscode-high-contrast, so test
+    // for the light variant explicitly rather than assuming HC means dark.
+    return cl.contains('vscode-light') || cl.contains('vscode-high-contrast-light')
+      ? 'light'
+      : 'dark';
   }
 
   function mermaidConfigFor(kind) {
@@ -168,6 +178,12 @@
   /** 1-based line number mermaid last reported an error on, or null. */
   let currentErrorLine = null;
   let errorBar = null;
+  /**
+   * The most recent source that parsed successfully — i.e. what the preview
+   * is actually showing, which may be older than textarea.value while the
+   * user is mid-edit (keep-last-good). Export and print render from this.
+   */
+  let lastGoodSource = null;
 
   function getErrorBar() {
     if (!errorBar) {
@@ -323,8 +339,13 @@
       preview.innerHTML = '';
       errorEl.hidden = true;
       currentErrorLine = null;
+      lastGoodSource = null;
       reapplyErrorLine();
       setExportButtonsEnabled(false);
+      // The next diagram is a fresh one — let it auto-fit rather than
+      // inheriting the previous diagram's pan/zoom (which could place it
+      // entirely off-screen).
+      hasAutoFitted = false;
       return;
     }
     const diagramId = 'mmd-diagram-' + seq;
@@ -344,6 +365,7 @@
       preview.innerHTML = svg;
       errorEl.hidden = true;
       currentErrorLine = null;
+      lastGoodSource = source;
       reapplyErrorLine();
 
       const svgEl = preview.querySelector('svg');
@@ -530,8 +552,13 @@
    * @returns {Promise<SVGSVGElement|null>}
    */
   async function renderThemedSvg(kind) {
-    const source = textarea.value;
-    if (!source.trim()) return null;
+    // Deliberately the last source that PARSED, not textarea.value. The
+    // preview keeps showing the last good diagram while the source is
+    // mid-edit and broken (keep-last-good), and export must match what the
+    // user is looking at — rendering the broken source would fail, silently
+    // fall back to the on-screen SVG, and export it in the wrong theme.
+    const source = lastGoodSource;
+    if (!source || !source.trim()) return null;
     const directive = '%%{init: ' + JSON.stringify({
       theme: 'base',
       themeVariables: Object.assign(
@@ -539,17 +566,22 @@
         THEME_VARIABLES[kind]
       ),
     }) + '}%%\n';
+    // Deliberately NOT renderSeq — bumping that would make an in-flight
+    // preview render see itself as superseded and silently bail.
+    const diagramId = 'mmd-export-' + (++exportSeq);
     try {
-      // Deliberately NOT renderSeq — bumping that would make an in-flight
-      // preview render see itself as superseded and silently bail.
       // @ts-ignore - mermaid global
-      const { svg } = await mermaid.render('mmd-export-' + (++exportSeq), directive + source);
+      const { svg } = await mermaid.render(diagramId, directive + source);
       const holder = document.createElement('div');
       holder.innerHTML = svg;
       const el = /** @type {SVGSVGElement|null} */ (holder.querySelector('svg'));
       if (el) applyDiagramStyling(el);
       return el;
     } catch (_) {
+      // Same scratch-node cleanup as the preview path — a failed render can
+      // leave mermaid's hidden container behind.
+      const orphan = document.getElementById('d' + diagramId);
+      if (orphan) orphan.remove();
       return null;
     }
   }
@@ -584,7 +616,20 @@
     // Re-render in the chosen theme rather than rasterizing what's on screen,
     // so a light-background export from a dark editor gets dark-on-light text
     // rather than an unreadable light-on-light image.
-    const themed = themeKind === currentThemeKind() ? null : await renderThemedSvg(themeKind);
+    let themed = null;
+    if (themeKind !== currentThemeKind()) {
+      themed = await renderThemedSvg(themeKind);
+      if (!themed) {
+        // Falling back to the on-screen SVG here would export the WRONG
+        // theme (e.g. a dark diagram onto a white canvas) while still
+        // reporting success. Fail loudly instead.
+        vscode.postMessage({
+          type: 'exportError',
+          message: 'Could not render the diagram for export. Fix any errors in the diagram and try again.',
+        });
+        return;
+      }
+    }
     const serialized = serializeSvg(themed || undefined);
     if (!serialized) return;
     const { text, w, h } = serialized;
@@ -600,9 +645,12 @@
         img.src = url;
       });
 
-      // 2x for crispness, clamped so a huge diagram can't blow past
-      // Chromium's canvas limits.
-      const scale = Math.max(1, Math.min(2, 8192 / Math.max(w, h)));
+      // 2x for crispness, but scale DOWN below 1 when necessary: a diagram
+      // wider than the cap would otherwise exceed Chromium's canvas limits,
+      // making toDataURL() return the empty "data:," and silently write a
+      // 0-byte file.
+      const MAX_DIMENSION = 8192;
+      const scale = Math.min(2, MAX_DIMENSION / Math.max(w, h));
       const canvas = document.createElement('canvas');
       canvas.width = Math.max(1, Math.ceil(w * scale));
       canvas.height = Math.max(1, Math.ceil(h * scale));
@@ -610,13 +658,20 @@
       // Fill with the editor background rather than leaving it transparent:
       // mermaid picks its theme from the VS Code theme, so a dark-theme
       // diagram has light text that would be invisible on white.
-      ctx.fillStyle = themeKind === 'light'
-        ? '#ffffff'
-        : (getComputedStyle(document.body).backgroundColor || '#1e1e1e');
+      ctx.fillStyle = EXPORT_BACKGROUND[themeKind] || EXPORT_BACKGROUND.dark;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 
-      const base64 = canvas.toDataURL('image/png').split(',')[1];
+      // A canvas that exceeded the browser's limits yields the empty
+      // "data:," rather than throwing — catch that here so it surfaces as an
+      // error instead of a success toast over a 0-byte file.
+      const dataUrl = canvas.toDataURL('image/png');
+      const base64 = dataUrl.startsWith('data:image/png;base64,')
+        ? dataUrl.slice('data:image/png;base64,'.length)
+        : '';
+      if (!base64) {
+        throw new Error('The diagram is too large to rasterize.');
+      }
       vscode.postMessage({ type: 'exportPng', base64: base64 });
     } catch (err) {
       vscode.postMessage({
@@ -643,7 +698,19 @@
   // light-on-white (i.e. invisible) or wastes a page of toner.
   btnPrint?.addEventListener('click', async () => {
     if (!preview.querySelector('svg')) return;
-    const themed = currentThemeKind() === 'light' ? null : await renderThemedSvg('light');
+    let themed = null;
+    if (currentThemeKind() !== 'light') {
+      themed = await renderThemedSvg('light');
+      if (!themed) {
+        // Same reasoning as exportPng: printing the on-screen dark diagram
+        // onto white paper is worse than telling the user why it failed.
+        vscode.postMessage({
+          type: 'exportError',
+          message: 'Could not render the diagram for printing. Fix any errors in the diagram and try again.',
+        });
+        return;
+      }
+    }
     const serialized = serializeSvg(themed || undefined);
     if (!serialized) return;
     vscode.postMessage({ type: 'print', svg: serialized.text });

--- a/media/mermaidEditor.js
+++ b/media/mermaidEditor.js
@@ -185,6 +185,24 @@
    */
   let lastGoodSource = null;
 
+  // ================================================
+  // Zoom & pan — state
+  // ================================================
+  // Declared here, above renderDiagram, because renderDiagram reads
+  // hasAutoFitted. `let` is in the temporal dead zone until its declaration
+  // executes, so declaring these below renderDiagram would work only by
+  // accident (nothing calls it during module evaluation) and would break the
+  // moment anything did. The behavior lives further down.
+  const ZOOM_MIN = 0.1;
+  const ZOOM_MAX = 8;
+  const ZOOM_STEP = 1.1;
+  const FIT_PADDING = 24;
+
+  let zoom = 1;
+  let panX = 0;
+  let panY = 0;
+  let hasAutoFitted = false;
+
   function getErrorBar() {
     if (!errorBar) {
       errorBar = document.createElement('div');
@@ -404,17 +422,9 @@
   }
 
   // ================================================
-  // Zoom & pan
+  // Zoom & pan — behavior
   // ================================================
-  const ZOOM_MIN = 0.1;
-  const ZOOM_MAX = 8;
-  const ZOOM_STEP = 1.1;
-  const FIT_PADDING = 24;
-
-  let zoom = 1;
-  let panX = 0;
-  let panY = 0;
-  let hasAutoFitted = false;
+  // (state is declared above renderDiagram, which reads it)
 
   function applyTransform() {
     preview.style.transform =

--- a/media/mermaidSyntax.js
+++ b/media/mermaidSyntax.js
@@ -1,0 +1,237 @@
+// @ts-nocheck
+// Mermaid syntax highlighting — tokenizer + HTML builder.
+//
+// Drives the highlight overlay in the .mmd editor: a <pre> layer rendered
+// underneath a transparent <textarea>. The textarea stays the real editing
+// surface (the whole document-sync design in mermaidEditor.js depends on it
+// being a real textarea), so this module only ever *reads* the source text
+// and produces display HTML.
+//
+// Exposed as a UMD-style module so it can be loaded both by the webview
+// (as a global `MermaidSyntax`) and by the Node test runner (via `require`).
+(function (global) {
+  'use strict';
+
+  /** Diagram-type keywords — the first meaningful token of a mermaid file. */
+  const DIAGRAM_KEYWORDS =
+    'graph|flowchart|sequenceDiagram|classDiagram|stateDiagram-v2|stateDiagram|erDiagram|' +
+    'journey|gantt|pie|gitGraph|mindmap|timeline|quadrantChart|requirementDiagram|' +
+    'C4Context|C4Container|C4Component|C4Dynamic|block-beta|sankey-beta|xychart-beta|' +
+    'architecture-beta';
+
+  /** Structural keywords shared across diagram types. */
+  const STRUCTURAL_KEYWORDS =
+    'subgraph|end|participant|actor|class|state|note|loop|alt|else|opt|par|and|rect|' +
+    'activate|deactivate|autonumber|title|section|click|style|classDef|linkStyle|' +
+    'direction|accTitle|accDescr';
+
+  // One master regex. Alternation order is load-bearing: JavaScript alternation
+  // is first-match-wins, not longest-match, so broader patterns must come after
+  // the narrower ones they could otherwise swallow.
+  //
+  //   1 string   — before arrows, so "a --> b" inside quotes stays one string
+  //   2 arrow    — before brackets, so `--o` isn't split into `--` + `o`
+  //   3 label    — |edge label|
+  //   4 bracket  — two-char node shapes before single chars
+  //   5 diagram  — diagram-type keywords
+  //   6 keyword  — structural keywords
+  //   7 direction
+  //   8 number
+  const MASTER_RE = new RegExp(
+    '("(?:[^"\\\\\\n]|\\\\.)*"?|`[^`\\n]*`?)' +
+    '|((?:<{1,2}|[xo])?(?:={2,}|-+\\.+-+|-{2,}|~{3,})(?:>{1,2}|[xo)])?|->>?|-[x)])' +
+    '|(\\|[^|\\n]*\\|)' +
+    '|(\\(\\(|\\)\\)|\\[\\[|\\]\\]|\\[\\(|\\)\\]|\\{\\{|\\}\\}|\\(\\[|\\]\\)|[\\[\\](){}])' +
+    '|\\b(' + DIAGRAM_KEYWORDS + ')\\b' +
+    '|\\b(' + STRUCTURAL_KEYWORDS + ')\\b' +
+    '|\\b(TD|TB|BT|RL|LR)\\b' +
+    '|\\b(\\d+(?:\\.\\d+)?)\\b',
+    'g'
+  );
+
+  // Capture-group index -> CSS class. Fixed whitelist: no user input ever
+  // reaches a class name (see escapeHtml note in buildHighlightHtml).
+  const GROUP_CLASSES = [
+    null,            // 0 — full match
+    'tok-string',    // 1
+    'tok-arrow',     // 2
+    'tok-label',     // 3
+    'tok-bracket',   // 4
+    'tok-diagram',   // 5
+    'tok-keyword',   // 6
+    'tok-direction', // 7
+    'tok-number',    // 8
+  ];
+
+  /**
+   * Tokenize a single line into [start, end, cssClass] triples covering only
+   * the classified spans (gaps between them are plain text).
+   *
+   * Per-line rather than whole-document because (a) `%%` comments are
+   * line-scoped, (b) it makes the error-line marking in mermaidEditor.js a
+   * simple per-line lookup, and (c) the only common multi-line construct is
+   * the `%%{init}%%` directive, carried across lines by `state.inDirective`.
+   *
+   * @param {string} line
+   * @param {{inDirective: boolean}} state mutated across lines by the caller
+   * @returns {Array<[number, number, string]>}
+   */
+  function tokenizeLine(line, state) {
+    const tokens = [];
+    let i = 0;
+
+    // Continuation of a multi-line %%{ ... }%% directive.
+    if (state.inDirective) {
+      const close = line.indexOf('}%%');
+      if (close === -1) {
+        if (line.length > 0) tokens.push([0, line.length, 'tok-directive']);
+        return tokens;
+      }
+      tokens.push([0, close + 3, 'tok-directive']);
+      state.inDirective = false;
+      i = close + 3;
+    }
+
+    const rest = line.slice(i);
+    const lead = rest.match(/^\s*/)[0].length;
+    const afterIndent = i + lead;
+
+    if (line.startsWith('%%{', afterIndent)) {
+      const close = line.indexOf('}%%', afterIndent);
+      if (close === -1) {
+        tokens.push([afterIndent, line.length, 'tok-directive']);
+        state.inDirective = true;
+        return tokens;
+      }
+      tokens.push([afterIndent, close + 3, 'tok-directive']);
+      i = close + 3;
+    } else if (line.startsWith('%%', afterIndent)) {
+      // A plain `%%` comment runs to end of line.
+      tokens.push([afterIndent, line.length, 'tok-comment']);
+      return tokens;
+    }
+
+    MASTER_RE.lastIndex = i;
+    let m;
+    while ((m = MASTER_RE.exec(line)) !== null) {
+      // Zero-length match guard — without this a pathological pattern could
+      // spin forever on the same index.
+      if (m[0] === '') {
+        MASTER_RE.lastIndex++;
+        continue;
+      }
+      for (let g = 1; g < GROUP_CLASSES.length; g++) {
+        if (m[g] !== undefined) {
+          tokens.push([m.index, m.index + m[0].length, GROUP_CLASSES[g]]);
+          break;
+        }
+      }
+    }
+    return tokens;
+  }
+
+  /**
+   * Escape text for safe insertion as HTML *text content*.
+   * `&` must be replaced first, or the `&` introduced by a later replacement
+   * would itself be double-escaped.
+   */
+  function escapeHtml(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  /**
+   * Build the highlight overlay's HTML for a whole document.
+   *
+   * Security: every byte of user text reaches the output through exactly one
+   * path — `escapeHtml(raw)` — so it can neither open a tag nor close one of
+   * ours. All markup is emitted by this function with class names drawn from
+   * the fixed GROUP_CLASSES whitelist above; no user input is ever
+   * interpolated into a tag or attribute. (Escape-then-wrap; the reverse
+   * order would either destroy our own spans or require re-identifying user
+   * text inside mixed markup, which is the classic XSS footgun.)
+   *
+   * Each line is wrapped in an inline span carrying its 1-based line number so
+   * the error-line marker can find it. The newline lives *inside* the span so
+   * `textContent` round-trips the source exactly.
+   *
+   * @param {string} source
+   * @returns {string}
+   */
+  function buildHighlightHtml(source) {
+    // Very large documents: skip colouring rather than stall the UI thread.
+    // Correctness (and an accurate textContent round-trip) is preserved.
+    if (source.length > 200000) {
+      return escapeHtml(source) + '\n';
+    }
+
+    const lines = source.split('\n');
+    const state = { inDirective: false };
+    let out = '';
+
+    for (let n = 0; n < lines.length; n++) {
+      const line = lines[n];
+      const tokens = tokenizeLine(line, state);
+      let lineHtml = '';
+      let pos = 0;
+
+      for (const [start, end, cls] of tokens) {
+        if (start > pos) lineHtml += escapeHtml(line.slice(pos, start));
+        lineHtml += '<span class="' + cls + '">' + escapeHtml(line.slice(start, end)) + '</span>';
+        pos = end;
+      }
+      if (pos < line.length) lineHtml += escapeHtml(line.slice(pos));
+
+      out += '<span class="mmd-line" data-line="' + (n + 1) + '">' + lineHtml + '\n</span>';
+    }
+
+    // Note each line span already carries its own trailing newline — including
+    // the last one, which the source itself doesn't have. That extra newline is
+    // deliberate: a <pre> collapses a trailing empty line that the textarea
+    // still shows, so without it their scrollHeights drift apart and the
+    // overlay misaligns at the bottom of the document. Do NOT add another here.
+    return out;
+  }
+
+  /**
+   * Pull a 1-based source line number out of a mermaid parse error.
+   *
+   * Mermaid's jison-generated parsers throw an Error carrying a `.hash`
+   * ({ line, loc: { first_line, ... } }); its message forms are
+   * "Parse error on line N:" / "Lexical error on line N." Newer
+   * langium-based diagram types (and UnknownDiagramError) may carry no line
+   * at all — callers must handle null.
+   *
+   * @param {unknown} err
+   * @param {string} source used only to clamp the result into range
+   * @returns {number|null} 1-based line number, or null if none available
+   */
+  function extractErrorLine(err, source) {
+    let line;
+    const hash = err && err.hash;
+    if (hash) {
+      if (hash.loc && typeof hash.loc.first_line === 'number') {
+        line = hash.loc.first_line; // already 1-based
+      } else if (typeof hash.line === 'number') {
+        line = hash.line + 1; // jison's yylineno is 0-based
+      }
+    }
+    if (line === undefined) {
+      const message = String((err && err.message) || err || '');
+      const m = /(?:Parse error|Lexical error) on line (\d+)/.exec(message) ||
+        /\bline\s+(\d+)/i.exec(message);
+      if (m) line = parseInt(m[1], 10);
+    }
+    if (line === undefined || !isFinite(line)) return null;
+    // Jison can report one past the last line at EOF.
+    const max = source.split('\n').length;
+    return Math.min(Math.max(1, line), max);
+  }
+
+  const api = { tokenizeLine, buildHighlightHtml, escapeHtml, extractErrorLine };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    global.MermaidSyntax = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "license": "MIT",
+  "author": {
+    "name": "Advancer Limited",
+    "url": "https://github.com/Advancer-Limited"
+  },
   "publisher": "advancer-limited",
   "icon": "media/icon.png",
   "repository": {

--- a/src/about.ts
+++ b/src/about.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+/**
+ * Show the extension's About dialog (product, version, author).
+ *
+ * Kept out of utils.ts deliberately: that module is imported directly by the
+ * Node test runner and must stay free of the `vscode` import.
+ */
+export async function showAboutDialog(context: vscode.ExtensionContext): Promise<void> {
+  const pkg = context.extension.packageJSON as Record<string, any>;
+  const author =
+    (typeof pkg.author === 'object' ? pkg.author?.name : pkg.author) ?? 'Advancer Limited';
+
+  await vscode.window.showInformationMessage(pkg.displayName ?? pkg.name, {
+    modal: true,
+    detail:
+      `Version ${pkg.version}\n` +
+      `By ${author}\n\n` +
+      `${pkg.description ?? ''}`,
+  });
+}

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
-import { getNonce, computeMinimalEdit } from './utils.js';
+import { getNonce, computeMinimalEdit, getBrandButtonHtml } from './utils.js';
 import { WebviewToExtensionMessage, GrammarMatch } from './types.js';
 import { FileIndexService } from './wikilink/fileIndexService.js';
+import { showAboutDialog } from './about.js';
 
 export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   public static readonly viewType = 'vscodeMdEditor.editor';
@@ -144,6 +145,10 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
           case 'requestGrammarCheck':
             vscode.commands.executeCommand('vscodeMdEditor.checkGrammar');
+            return;
+
+          case 'showAbout':
+            await showAboutDialog(this.context);
             return;
 
           case 'requestWikilinkSuggestions': {
@@ -301,6 +306,8 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       <button id="btn-split" title="Split View">Split</button>
       <button id="btn-editor-only" title="Raw Markdown">Raw</button>
     </div>
+    <span class="toolbar-separator"></span>
+    ${getBrandButtonHtml()}
   </div>
   <div class="editor-container preview-only" id="editor-container">
     <div class="editor-pane" id="editor-pane">

--- a/src/mermaidEditorProvider.ts
+++ b/src/mermaidEditorProvider.ts
@@ -1,6 +1,41 @@
 import * as vscode from 'vscode';
-import { getNonce, computeMinimalEdit } from './utils.js';
+import * as path from 'path';
+import { getNonce, computeMinimalEdit, getBrandButtonHtml } from './utils.js';
 import { MermaidWebviewToExtensionMessage } from './types.js';
+import { showAboutDialog } from './about.js';
+
+/** Escape text for safe interpolation into HTML text content. */
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Build a standalone page containing just the diagram, for printing in an
+ * external browser. Carries its own strict CSP (no script-src at all) as
+ * defence in depth — nothing executable should reach the user's real browser
+ * even if mermaid's sanitization were ever bypassed.
+ */
+function buildPrintHtml(title: string, svg: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">
+<title>${escapeHtml(title)}</title>
+<style>
+  body { margin: 0; display: flex; justify-content: center; align-items: flex-start; padding: 16px; }
+  svg { max-width: 100%; height: auto; }
+  @media print {
+    @page { margin: 12mm; }
+    body { padding: 0; }
+    svg { max-width: 100%; max-height: 100vh; page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>${svg}</body>
+</html>`;
+}
 
 /**
  * CustomTextEditorProvider for Mermaid diagram source files (*.mmd, *.mermaid).
@@ -115,6 +150,84 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
             }
             return;
           }
+
+          // The cases below are pure side-channels: they never touch
+          // applyingEdits/lastAppliedText or call updateWebview(), so they
+          // cannot interfere with document sync.
+
+          case 'requestPngExport': {
+            const choice = await vscode.window.showQuickPick(
+              [
+                {
+                  label: 'Light background',
+                  description: 'White background, dark text — best for documents and slides',
+                  theme: 'light' as const,
+                },
+                {
+                  label: 'Dark background',
+                  description: 'Matches a dark editor theme',
+                  theme: 'dark' as const,
+                },
+              ],
+              { title: 'Export diagram as PNG', placeHolder: 'Choose the image background' }
+            );
+            if (!choice) {
+              return; // user cancelled
+            }
+            webviewPanel.webview.postMessage({ type: 'exportPngTheme', theme: choice.theme });
+            return;
+          }
+
+          case 'exportPng': {
+            const base = path
+              .basename(document.fileName)
+              .replace(/\.(mmd|mermaid)$/i, '');
+            const target = await vscode.window.showSaveDialog({
+              defaultUri: vscode.Uri.joinPath(document.uri, '..', `${base}.png`),
+              filters: { 'PNG Image': ['png'] },
+            });
+            if (!target) {
+              return; // user cancelled
+            }
+            await vscode.workspace.fs.writeFile(
+              target,
+              Buffer.from(message.base64, 'base64')
+            );
+            vscode.window.showInformationMessage(
+              `Exported ${path.basename(target.fsPath)}`
+            );
+            return;
+          }
+
+          case 'exportError':
+            vscode.window.showErrorMessage(`Diagram export failed: ${message.message}`);
+            return;
+
+          case 'showAbout':
+            await showAboutDialog(this.context);
+            return;
+
+          case 'print': {
+            // window.print() is suppressed inside VS Code's sandboxed webview
+            // iframes (no allow-modals), and fails silently. Write a
+            // standalone page and hand it to the real browser, where Print —
+            // and its "Save as PDF" destination — works properly.
+            try {
+              const dir = this.context.globalStorageUri;
+              await vscode.workspace.fs.createDirectory(dir);
+              const file = vscode.Uri.joinPath(dir, `mmd-print-${Date.now()}.html`);
+              await vscode.workspace.fs.writeFile(
+                file,
+                Buffer.from(buildPrintHtml(path.basename(document.fileName), message.svg), 'utf8')
+              );
+              await vscode.env.openExternal(file);
+            } catch (err) {
+              vscode.window.showErrorMessage(
+                `Failed to open the diagram for printing: ${err instanceof Error ? err.message : String(err)}`
+              );
+            }
+            return;
+          }
         }
       }
     );
@@ -145,6 +258,9 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
     const mermaidUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this.context.extensionUri, 'media', 'mermaid.min.js')
     );
+    const syntaxUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.context.extensionUri, 'media', 'mermaidSyntax.js')
+    );
 
     return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -163,18 +279,36 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
 <body>
   <div class="mmd-container" id="mmd-container">
     <div class="mmd-editor-pane" id="mmd-editor-pane">
-      <textarea id="mmd-input"
-                spellcheck="false"
-                placeholder="Enter Mermaid diagram source..."
-      ></textarea>
+      <div class="mmd-editor-stack" id="mmd-editor-stack">
+        <pre class="mmd-highlight" id="mmd-highlight" aria-hidden="true"><code id="mmd-highlight-code"></code></pre>
+        <textarea id="mmd-input"
+                  spellcheck="false"
+                  placeholder="Enter Mermaid diagram source..."
+        ></textarea>
+      </div>
     </div>
     <div class="mmd-divider" id="mmd-divider"></div>
     <div class="mmd-preview-pane" id="mmd-preview-pane">
-      <div id="mmd-preview"></div>
+      <div class="mmd-toolbar" id="mmd-toolbar">
+        <button id="mmd-zoom-out" title="Zoom out">&minus;</button>
+        <span id="mmd-zoom-readout" class="mmd-zoom-readout" title="Click to reset zoom">100%</span>
+        <button id="mmd-zoom-in" title="Zoom in">+</button>
+        <button id="mmd-zoom-reset" title="Reset zoom to 100%">1:1</button>
+        <button id="mmd-zoom-fit" title="Fit diagram to view">Fit</button>
+        <span class="mmd-toolbar-separator"></span>
+        <button id="mmd-export-png" title="Export diagram as a PNG image">PNG</button>
+        <button id="mmd-print" title="Open in browser to print or save as PDF">Print</button>
+        <span class="mmd-toolbar-spacer"></span>
+        ${getBrandButtonHtml()}
+      </div>
+      <div class="mmd-viewport" id="mmd-viewport">
+        <div id="mmd-preview" class="mmd-canvas"></div>
+      </div>
       <div id="mmd-error" class="mmd-error" hidden></div>
     </div>
   </div>
   <script nonce="${nonce}" src="${mermaidUri}?v=${cacheBust}"></script>
+  <script nonce="${nonce}" src="${syntaxUri}?v=${cacheBust}"></script>
   <script nonce="${nonce}" src="${scriptUri}?v=${cacheBust}"></script>
 </body>
 </html>`;

--- a/src/mermaidEditorProvider.ts
+++ b/src/mermaidEditorProvider.ts
@@ -9,6 +9,35 @@ function escapeHtml(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+/** How long a generated print page is kept before being swept. */
+const PRINT_FILE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Delete previously generated print pages that are older than the TTL.
+ *
+ * They can't be removed immediately after opening — the browser loads them
+ * asynchronously — so they're swept on the next print instead. Without this
+ * they accumulate indefinitely, each holding a full copy of a diagram.
+ */
+async function sweepOldPrintFiles(dir: vscode.Uri): Promise<void> {
+  try {
+    const cutoff = Date.now() - PRINT_FILE_TTL_MS;
+    const entries = await vscode.workspace.fs.readDirectory(dir);
+    for (const [name, type] of entries) {
+      if (type !== vscode.FileType.File) continue;
+      const match = /^mmd-print-(\d+)\.html$/.exec(name);
+      if (!match || Number(match[1]) >= cutoff) continue;
+      try {
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(dir, name));
+      } catch {
+        // A file we can't delete shouldn't block printing.
+      }
+    }
+  } catch {
+    // Sweeping is best-effort housekeeping — never fail a print over it.
+  }
+}
+
 /**
  * Build a standalone page containing just the diagram, for printing in an
  * external browser. Carries its own strict CSP (no script-src at all) as
@@ -179,6 +208,10 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
           }
 
           case 'exportPng': {
+            if (typeof message.base64 !== 'string' || message.base64.length === 0) {
+              vscode.window.showErrorMessage('Diagram export failed: no image data was produced.');
+              return;
+            }
             const base = path
               .basename(document.fileName)
               .replace(/\.(mmd|mermaid)$/i, '');
@@ -189,13 +222,20 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
             if (!target) {
               return; // user cancelled
             }
-            await vscode.workspace.fs.writeFile(
-              target,
-              Buffer.from(message.base64, 'base64')
-            );
-            vscode.window.showInformationMessage(
-              `Exported ${path.basename(target.fsPath)}`
-            );
+            try {
+              const bytes = Buffer.from(message.base64, 'base64');
+              if (bytes.length === 0) {
+                throw new Error('decoded image was empty');
+              }
+              await vscode.workspace.fs.writeFile(target, bytes);
+              vscode.window.showInformationMessage(
+                `Exported ${path.basename(target.fsPath)}`
+              );
+            } catch (err) {
+              vscode.window.showErrorMessage(
+                `Failed to save the diagram: ${err instanceof Error ? err.message : String(err)}`
+              );
+            }
             return;
           }
 
@@ -215,6 +255,7 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
             try {
               const dir = this.context.globalStorageUri;
               await vscode.workspace.fs.createDirectory(dir);
+              await sweepOldPrintFiles(dir);
               const file = vscode.Uri.joinPath(dir, `mmd-print-${Date.now()}.html`);
               await vscode.workspace.fs.writeFile(
                 file,

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,9 @@ export type WebviewToExtensionMessage =
   | { type: 'requestGrammarCheck' }
   | { type: 'requestWikilinkSuggestions'; prefix: string }
   | { type: 'openWikilink'; target: string }
-  | { type: 'applyGrammarFix'; offset: number; length: number; replacement: string; expectedText?: string };
+  | { type: 'applyGrammarFix'; offset: number; length: number; replacement: string; expectedText?: string }
+  /** Toolbar brand button — show the About dialog. */
+  | { type: 'showAbout' };
 
 export interface WikilinkSuggestion {
   stem: string;
@@ -168,12 +170,27 @@ export type FullGraphToExtensionMessage =
 /** Messages from extension host -> mermaid editor webview */
 export type MermaidEditorToWebviewMessage =
   | { type: 'update'; text: string }
-  | { type: 'editAck' };
+  | { type: 'editAck' }
+  /** Result of the export-theme QuickPick; the webview then rasterizes. */
+  | { type: 'exportPngTheme'; theme: 'light' | 'dark' };
 
 /** Messages from mermaid editor webview -> extension host */
 export type MermaidWebviewToExtensionMessage =
   | { type: 'ready' }
-  | { type: 'edit'; text: string };
+  | { type: 'edit'; text: string }
+  /** Asks the host to prompt for an image theme before rasterizing. */
+  | { type: 'requestPngExport' }
+  /** Rasterized diagram, base64-encoded PNG, for the host to save to disk. */
+  | { type: 'exportPng'; base64: string }
+  | { type: 'exportError'; message: string }
+  /** Toolbar brand button — show the About dialog. */
+  | { type: 'showAbout' }
+  /**
+   * Serialized SVG to print. The host writes it to a standalone HTML file and
+   * opens it externally — window.print() is suppressed inside VS Code's
+   * sandboxed webview iframes, so printing cannot be done in the webview.
+   */
+  | { type: 'print'; svg: string };
 
 // ========================================
 // Extension Configuration

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,30 @@ export function debounce(fn: (...args: any[]) => any, delayMs: number): (...args
 }
 
 /**
+ * The Advancer mark, as inline SVG for a toolbar button.
+ *
+ * Inline rather than an <img> so it needs no `img-src` allowance and adds no
+ * extra request; `currentColor` is deliberately avoided so the brand keeps its
+ * colours in both light and dark themes.
+ */
+export function getBrandButtonHtml(): string {
+  return /* html */ `<button id="btn-about" class="brand-button" title="About this extension" aria-label="About this extension">
+    <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="advancerBrandGradient" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stop-color="#c084fc"/>
+          <stop offset="55%" stop-color="#a855f7"/>
+          <stop offset="100%" stop-color="#6b21a8"/>
+        </linearGradient>
+      </defs>
+      <path fill="url(#advancerBrandGradient)" fill-rule="evenodd" clip-rule="evenodd"
+            d="M12 2.5 L22 21 L2 21 Z M12 9.6 L16.1 17.2 L7.9 17.2 Z"/>
+      <path fill="#581c87" d="M2 21 L6.6 12.5 L9.1 17.2 L7 21 Z"/>
+    </svg>
+  </button>`;
+}
+
+/**
  * Case-insensitively test whether a path (or URI fsPath) has a markdown
  * extension — `.md` or `.markdown`. The extension's customEditors selector
  * (package.json) claims both extensions, so anything gating markdown-only

--- a/tests/mermaidSyntax.test.mjs
+++ b/tests/mermaidSyntax.test.mjs
@@ -1,0 +1,266 @@
+// Unit tests for the Mermaid syntax tokenizer (media/mermaidSyntax.js).
+//
+// The tokenizer output is assigned to innerHTML in the .mmd editor's highlight
+// overlay, so the escaping tests here are security-critical, not cosmetic.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { buildHighlightHtml, tokenizeLine, escapeHtml, extractErrorLine } =
+  require('../media/mermaidSyntax.js');
+
+/** Reverse escapeHtml. `&amp;` must be undone last, mirroring the escape order. */
+function unescapeHtml(s) {
+  return s.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+}
+
+/** Strip tags to recover the rendered text, as the DOM's textContent would. */
+function renderedText(html) {
+  return unescapeHtml(html.replace(/<[^>]*>/g, ''));
+}
+
+/**
+ * Classes applied to a given substring, for asserting tokenization.
+ * Token text is compared after unescaping, so callers pass the raw source
+ * text (e.g. `-->`), not its escaped form (`--&gt;`).
+ */
+function classesFor(html, text) {
+  const out = [];
+  const re = /<span class="(tok-[a-z]+)">([^<]*)<\/span>/g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    if (unescapeHtml(m[2]) === text) out.push(m[1]);
+  }
+  return out;
+}
+
+// ============================================================
+// Round-trip invariant — the overlay must mirror the source exactly
+// ============================================================
+
+test('rendered text round-trips the source exactly (plus the layout newline)', () => {
+  const sources = [
+    'graph TD\nA[Start] --> B[End]',
+    'flowchart LR\n  A --> B\n  B --> C',
+    '',
+    '\n\n\n',
+    'sequenceDiagram\n  Alice->>John: Hello\n  John-->>Alice: Hi',
+    'graph TD\n  A["quoted ] bracket"] --> B',
+    '  \t indented\twith\ttabs',
+  ];
+  for (const src of sources) {
+    assert.strictEqual(
+      renderedText(buildHighlightHtml(src)),
+      src + '\n',
+      `round-trip failed for ${JSON.stringify(src)}`
+    );
+  }
+});
+
+test('trailing newline in source is preserved (scroll-height parity)', () => {
+  assert.strictEqual(renderedText(buildHighlightHtml('graph TD\n')), 'graph TD\n\n');
+});
+
+// ============================================================
+// Escaping / injection — security critical
+// ============================================================
+
+test('HTML metacharacters in the source are escaped, not emitted as markup', () => {
+  const html = buildHighlightHtml('graph TD\n  A["<b>bold</b>"] --> B');
+  assert.ok(!/<b>/.test(html), 'raw <b> tag leaked into the overlay HTML');
+  assert.ok(html.includes('&lt;b&gt;'), 'expected escaped markup');
+});
+
+test('a script tag in a node label cannot break out of the overlay', () => {
+  const attack = 'graph TD\n  A["</code><script>window.pwned=1</script>"] --> B';
+  const html = buildHighlightHtml(attack);
+  assert.ok(!/<script/i.test(html), 'unescaped <script> present in output');
+  assert.ok(!/<\/code>/i.test(html), 'unescaped </code> could terminate the overlay element');
+  assert.strictEqual(renderedText(html), attack + '\n');
+});
+
+test('an img/onerror payload is escaped', () => {
+  const attack = 'graph TD\n  A --> B & <img src=x onerror=alert(1)>';
+  const html = buildHighlightHtml(attack);
+  assert.ok(!/<img/i.test(html), 'unescaped <img> present in output');
+  assert.ok(html.includes('&lt;img'), 'expected escaped img tag');
+});
+
+test('ampersands are escaped once, not double-escaped', () => {
+  // & must be replaced before < and >, or "&lt;" would become "&amp;lt;".
+  assert.strictEqual(escapeHtml('a & b'), 'a &amp; b');
+  assert.strictEqual(escapeHtml('<a>'), '&lt;a&gt;');
+  assert.strictEqual(escapeHtml('&lt;'), '&amp;lt;');
+  assert.strictEqual(renderedText(buildHighlightHtml('A & B')), 'A & B\n');
+});
+
+test('a quote character cannot escape a class attribute', () => {
+  // Class names come from a fixed whitelist, never from user input — this
+  // asserts the property rather than the implementation.
+  const html = buildHighlightHtml('graph TD\n  A["\\" onload=x"] --> B');
+  const classAttrs = [...html.matchAll(/class="([^"]*)"/g)].map((m) => m[1]);
+  for (const cls of classAttrs) {
+    assert.ok(
+      /^(tok-[a-z]+|mmd-line)$/.test(cls),
+      `unexpected class attribute value: ${JSON.stringify(cls)}`
+    );
+  }
+});
+
+// ============================================================
+// Tokenization
+// ============================================================
+
+test('diagram-type keywords are tokenized', () => {
+  assert.deepStrictEqual(classesFor(buildHighlightHtml('graph TD'), 'graph'), ['tok-diagram']);
+  assert.deepStrictEqual(classesFor(buildHighlightHtml('flowchart LR'), 'flowchart'), ['tok-diagram']);
+  assert.deepStrictEqual(
+    classesFor(buildHighlightHtml('sequenceDiagram'), 'sequenceDiagram'),
+    ['tok-diagram']
+  );
+  // stateDiagram-v2 must win over the shorter stateDiagram alternative.
+  assert.deepStrictEqual(
+    classesFor(buildHighlightHtml('stateDiagram-v2'), 'stateDiagram-v2'),
+    ['tok-diagram']
+  );
+});
+
+test('directions are tokenized', () => {
+  for (const dir of ['TD', 'TB', 'BT', 'RL', 'LR']) {
+    assert.deepStrictEqual(
+      classesFor(buildHighlightHtml('graph ' + dir), dir),
+      ['tok-direction'],
+      `direction ${dir} not tokenized`
+    );
+  }
+});
+
+test('arrow forms are tokenized, longest-match-first', () => {
+  const cases = ['-->', '---', '-.->', '==>', '--x', '--o', '~~~', '->>', '-->>', '<-->'];
+  for (const arrow of cases) {
+    const html = buildHighlightHtml('graph TD\n  A ' + arrow + ' B');
+    assert.deepStrictEqual(
+      classesFor(html, arrow),
+      ['tok-arrow'],
+      `arrow ${JSON.stringify(arrow)} was not tokenized as a single arrow token`
+    );
+  }
+});
+
+test('comments are tokenized and run to end of line', () => {
+  const html = buildHighlightHtml('graph TD\n%% this --> is not an arrow\nA --> B');
+  assert.deepStrictEqual(
+    classesFor(html, '%% this --> is not an arrow'),
+    ['tok-comment'],
+    'comment did not consume the whole line'
+  );
+});
+
+test('an indented comment is still a comment', () => {
+  const html = buildHighlightHtml('graph TD\n    %% indented note');
+  assert.deepStrictEqual(classesFor(html, '%% indented note'), ['tok-comment']);
+});
+
+test('arrows inside a quoted string are part of the string, not arrows', () => {
+  const html = buildHighlightHtml('graph TD\n  A["a --> b"] --> B');
+  assert.deepStrictEqual(classesFor(html, '"a --> b"'), ['tok-string']);
+  // The real arrow outside the string is still tokenized.
+  assert.ok(classesFor(html, '-->').includes('tok-arrow'));
+});
+
+test('edge labels are tokenized', () => {
+  const html = buildHighlightHtml('graph TD\n  A -->|yes| B');
+  assert.deepStrictEqual(classesFor(html, '|yes|'), ['tok-label']);
+});
+
+test('node-shape brackets are tokenized', () => {
+  const html = buildHighlightHtml('graph TD\n  A[Box] --> B((Circle))');
+  assert.ok(classesFor(html, '[').includes('tok-bracket'));
+  assert.ok(classesFor(html, '((').includes('tok-bracket'));
+});
+
+test('structural keywords are tokenized', () => {
+  const html = buildHighlightHtml('graph TD\n  subgraph one\n    A --> B\n  end');
+  assert.deepStrictEqual(classesFor(html, 'subgraph'), ['tok-keyword']);
+  assert.deepStrictEqual(classesFor(html, 'end'), ['tok-keyword']);
+});
+
+test('numbers are tokenized', () => {
+  const html = buildHighlightHtml('pie\n  "A" : 42');
+  assert.deepStrictEqual(classesFor(html, '42'), ['tok-number']);
+});
+
+test('%%{init}%% directives are tokenized, including across lines', () => {
+  const single = buildHighlightHtml("%%{init: {'theme':'dark'}}%%\ngraph TD");
+  assert.ok(/tok-directive/.test(single), 'single-line directive not tokenized');
+
+  const multi = buildHighlightHtml("%%{init: {\n  'theme': 'dark'\n}}%%\ngraph TD");
+  const directiveCount = (multi.match(/tok-directive/g) || []).length;
+  assert.ok(directiveCount >= 2, 'multi-line directive should span multiple line spans');
+  // The directive must close: `graph` after it is highlighted as a diagram keyword.
+  assert.deepStrictEqual(classesFor(multi, 'graph'), ['tok-diagram']);
+});
+
+test('every line gets a numbered line span', () => {
+  const html = buildHighlightHtml('graph TD\nA --> B\nB --> C');
+  assert.ok(html.includes('data-line="1"'));
+  assert.ok(html.includes('data-line="2"'));
+  assert.ok(html.includes('data-line="3"'));
+});
+
+test('tokenizeLine never loops forever on odd input', () => {
+  const state = { inDirective: false };
+  // Just needs to terminate.
+  for (const line of ['', '   ', '%%', '%%{', '}%%', '-', '"', '|', '[[', '((((']) {
+    assert.doesNotThrow(() => tokenizeLine(line, state));
+  }
+});
+
+test('very large documents fall back to plain escaped text but still round-trip', () => {
+  const big = 'graph TD\n' + 'A --> B\n'.repeat(30000);
+  assert.ok(big.length > 200000, 'fixture should exceed the size threshold');
+  const html = buildHighlightHtml(big);
+  assert.ok(!html.includes('tok-'), 'expected the unstyled fallback for a very large document');
+  assert.strictEqual(renderedText(html), big + '\n');
+});
+
+// ============================================================
+// Error line extraction
+// ============================================================
+
+test('extracts a line number from a jison hash with loc (1-based)', () => {
+  const err = { message: 'boom', hash: { loc: { first_line: 3 } } };
+  assert.strictEqual(extractErrorLine(err, 'a\nb\nc\nd'), 3);
+});
+
+test('extracts a line number from a jison hash line (0-based)', () => {
+  const err = { message: 'boom', hash: { line: 2 } };
+  assert.strictEqual(extractErrorLine(err, 'a\nb\nc\nd'), 3);
+});
+
+test('falls back to parsing the message text', () => {
+  assert.strictEqual(
+    extractErrorLine(new Error('Parse error on line 2:\n...'), 'a\nb\nc'),
+    2
+  );
+  assert.strictEqual(
+    extractErrorLine(new Error('Lexical error on line 3. Unrecognized text.'), 'a\nb\nc'),
+    3
+  );
+});
+
+test('returns null when no line information is available', () => {
+  assert.strictEqual(
+    extractErrorLine(new Error('No diagram type detected matching given configuration'), 'a\nb'),
+    null
+  );
+  assert.strictEqual(extractErrorLine(null, 'a\nb'), null);
+  assert.strictEqual(extractErrorLine(undefined, 'a\nb'), null);
+});
+
+test('clamps an out-of-range line into the document', () => {
+  // Jison can report one past the last line at EOF.
+  assert.strictEqual(extractErrorLine({ hash: { loc: { first_line: 99 } } }, 'a\nb\nc'), 3);
+  assert.strictEqual(extractErrorLine({ hash: { loc: { first_line: 0 } } }, 'a\nb\nc'), 1);
+});

--- a/todo.md
+++ b/todo.md
@@ -162,3 +162,23 @@
 - [ ] Mermaid diagram rendering in the diff view itself (a changed diagram currently shows as plain fenced-code hunks, not rendered SVG) — needs the shared mermaid vendor files from #44/#45 merged first
 - [ ] `.mmd` file diff support (side-by-side rendered old/new diagram) — diff commands aren't yet gated for `.mmd` in package.json menus
 - [ ] #44 and #45 both independently vendor `mermaid` as a dependency (built in parallel off develop) — trivial duplicate-addition conflict expected in package.json/package-lock.json when both merge
+
+## 2026-07-19 Mermaid editor overhaul + 1.0.0 (PR #50)
+
+- [x] Capture a behavioral baseline suite of the existing .mmd editor (14 checks) BEFORE changing anything, as an explicit regression contract
+- [x] Syntax highlighting in the .mmd source pane (transparent-textarea-over-<pre> overlay; tokenizer extracted to media/mermaidSyntax.js with 26 committed unit tests incl. HTML-injection cases)
+- [x] Error-line marking when a diagram fails to parse
+- [x] Zoom/pan in the diagram preview, transform preserved across re-renders
+- [x] PNG export with light/dark background choice (native QuickPick)
+- [x] Print via host -> temp HTML -> external browser (window.print() is suppressed in VS Code webviews)
+- [x] Professional diagram restyle + light/dark theming with live theme-switch re-render
+- [x] About/brand button on both editor toolbars
+- [x] Bump to 1.0.0, add author field, update README/CHANGELOG
+- [x] Fable adversarial review; fixed 3 bugs + 4 risks it found (see log.md)
+
+### Deferred / follow-up work
+- [ ] PR: Mermaid toolbox (snippet palette, template gallery) + IntelliSense-style autocomplete in the raw view
+- [ ] PR: glTF 3D viewer — `.gltf` raw view + three.js preview with zoom/orbit navigation (Fable to design; decide live-rerender-preserving-viewport vs an explicit Update button)
+- [ ] Evaluate D2 (`@terrastruct/d2`, MPL-2.0) as a second diagram renderer for architecture diagrams — needs `wasm-unsafe-eval` + `worker-src blob:` CSP additions, ~8MB bundle
+- [ ] AVOID PlantUML: core is GPL. An MIT-flavoured `@plantuml/core` build exists but is very new and its MIT-ness depends on the maintainer gating GPL paths each release — unacceptable risk given the intent to keep commercial options open
+- [ ] Clickable/editable mermaid diagrams in the markdown WYSIWYG view (currently read-only by design — Turndown round-trip would mangle an editable SVG)


### PR DESCRIPTION
## Summary

Substantial upgrade to the `.mmd`/`.mermaid` editor, plus 1.0.0 release prep.

**Source pane**
- **Syntax highlighting** — transparent-textarea-over-highlighted-`<pre>` overlay. Tokenizer extracted to `media/mermaidSyntax.js` (following the `turndownTableRules.js` precedent) so it's unit-testable: 26 committed tests covering tokenization, exact source round-trip, and HTML-injection attempts — its output goes to `innerHTML`, so escaping is security-critical.
- **Error-line marking** — a failed parse highlights the offending line (structured jison error hash first, message-text fallback, banner-only when mermaid reports no line).

**Preview pane**
- **Zoom/pan** — Ctrl/Cmd+wheel zooms about the pointer, drag to pan, toolbar for in/out/1:1/fit + live percentage. The transform is preserved across re-renders; previously the view reset on every keystroke, which made zooming into a large diagram useless.
- **PNG export** with a light/dark background choice via native QuickPick. A light export *re-renders* rather than rasterizing the on-screen dark diagram (which would be unreadable light-on-white).
- **Print** — opens in the external browser for the real print dialog / Save-as-PDF.
- **Refreshed visuals** — rounded corners, flatter professional palette, cleaner typography, proper light/dark theming with live re-render on theme change.

**Also**: About/brand button on both editor toolbars, version → 1.0.0, `author` field added, README/CHANGELOG updated.

## ⚠️ Notable finding: `window.print()` does not work in VS Code webviews

They're sandboxed iframes without `allow-modals`, so the print dialog is suppressed — and it fails **silently** (no dialog, no error). VS Code's own markdown preview has the same limitation ([microsoft/vscode#109237](https://github.com/microsoft/vscode/issues/109237)). Print therefore goes webview → host → temp HTML → `openExternal`. Worth knowing before anyone "simplifies" this back to `window.print()`.

## Not breaking existing behavior

The `.mmd` editor's document-sync logic is subtle (echo suppression, CRLF normalization, in-flight edit tracking, stale-render guards). Rather than assert it still works:

1. Captured a **14-check behavioral suite against the pre-change code** — baseline 14/14.
2. Re-ran it after every change — still **14/14**.

An adversarial review pass independently confirmed the sync-critical block is **byte-identical to develop**.

## Review pass

A second review found **3 real bugs and 4 risks**, all in the new export path, all fixed in `3eab3a2`:

1. A "dark" export from a *light* editor filled the canvas from the live (light) background → light-on-light output.
2. Export/print with a broken source silently fell back to the on-screen SVG in the wrong theme **and reported success**.
3. Diagrams wider than 8192px produced a **0-byte PNG with a success toast** (scale was floored at 1; an over-limit canvas makes `toDataURL()` return `"data:,"` rather than throwing).
4. Scratch-node leak on failed themed render; unguarded host write; print temp files accumulating forever; `vscode-high-contrast-light` misclassified as dark.

The reviewer asked for a manual check that `scrollbar-gutter: stable` really equalises content width in both scrolling and non-scrolling states (it's what keeps the overlay glyph-aligned) — automated instead; passes both.

## Verification

`check-types` and `compile` clean. **66** unit tests, **14** behavioral regression, **23** new-feature Playwright, **7** review-fix Playwright — all passing.

Empirically established while building (worth recording): mermaid emits `width="100%"` with **no** `height`, so export dimensions must come from the `viewBox`; its `<foreignObject>` labels **do** rasterize correctly in Chromium; and inline-SVG-via-`data:`-URL does **not** taint the canvas, so no CSP change was needed.

## Test plan

- [ ] Open a `.mmd` file — confirm syntax highlighting, and that the caret lands exactly where the coloured text appears (especially on long wrapped lines)
- [ ] Introduce a syntax error — confirm the offending line is marked and the last valid diagram stays visible
- [ ] Zoom/pan, then keep typing — confirm the view is not reset
- [ ] Export PNG in both light and dark from both a light and a dark VS Code theme — confirm all four are readable
- [ ] Print — confirm it opens in the browser and Save-as-PDF produces a light diagram
- [ ] Switch VS Code theme with a diagram open — confirm it re-renders
- [ ] Click the About button on both the markdown and mermaid toolbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)