### PR TITLE
feat: mermaid authoring assistance — templates, snippet palette, completions

### DIFF
--- a/log.md
+++ b/log.md
@@ -502,3 +502,22 @@ Before touching anything, captured a 14-check behavioral suite against the *exis
 
 ### Verification
 66 unit tests, 14 behavioral regression, 23 new-feature Playwright, 7 review-fix Playwright — all passing; `check-types` and `compile` clean.
+
+## 2026-07-19 — Mermaid authoring assistance (toolbox + completions)
+
+Follow-on to the mermaid editor overhaul. Same method: pure logic extracted to a UMD module for the Node test runner, DOM work in the webview, and the existing Playwright suites re-run as a regression gate before anything else.
+
+### What was built
+- `media/mermaidCompletions.js` — diagram templates, the context-aware snippet palette, the node-id scanner and the completion engine. No DOM access, so it is unit tested directly (28 tests).
+- **Template gallery** (8 starter diagrams) — the highest value-per-effort item: it solves "I can never remember mermaid syntax" outright. Replacing a non-empty document asks for confirmation first.
+- **Snippet palette**, rebuilt only when the detected diagram type changes (avoids DOM churn on every keystroke).
+- **Completion overlay** — VS Code's CompletionItemProvider does not apply to a textarea in a webview, so this is a custom overlay modelled on the markdown editor's `[[wikilink]]` autocomplete. Offers node ids after an arrow (the standout: a typo'd node id doesn't error in mermaid, it silently creates an orphan), plus diagram types, directions, keywords and arrows.
+- All insertion goes through `document.execCommand('insertText')` so the browser's native undo stack survives and a real `input` event fires — which is what drives the existing highlight refresh, render debounce and document sync. Assigning `textarea.value` directly would break undo AND fire no event, silently desyncing the document. There is a manual splice + synthetic event fallback in case execCommand is ever removed.
+
+### Bugs caught during verification
+1. **Completion list closed the instant it opened.** The `scroll` handler hid it, and typing itself scrolls the textarea to keep the caret visible. Fixed by repositioning on scroll instead of hiding — which is the better behavior anyway.
+2. **Overlay swallowed toolbar clicks** (caught by the *existing* feature suite, not the new one — the regression gate earning its keep). The overlay clamped to the window edge, so a long line pushed it over the preview pane where it covered the toolbar. Now clamped to the source pane, plus an outside-mousedown dismiss.
+3. **Layout broken — caught only by looking at a screenshot, with all 61 automated checks passing.** `.mmd-editor-pane` is `display: flex` with default row direction, so the new source toolbar became a row-sibling and squeezed the text into a one-character-wide strip. Fixed with `flex-direction: column` (+ `min-height: 0` on the stack instead of `height: 100%`, which would now overflow by the toolbar's height). A good reminder that behavioral tests keyed on element IDs say nothing about whether the thing is usable.
+
+### Verification
+94 unit tests (66 existing + 28 new); 61 Playwright checks (14 behavioral regression, 23 feature, 7 review-fix, 17 new toolbox/completions); check-types and compile clean.

--- a/media/mermaidCompletions.js
+++ b/media/mermaidCompletions.js
@@ -1,0 +1,407 @@
+// @ts-nocheck
+// Mermaid authoring assistance: diagram templates, a context-aware snippet
+// palette, and completion suggestions for the .mmd source pane.
+//
+// Pure data + string logic, deliberately free of DOM access so it can be
+// unit tested by the Node test runner (same rationale as mermaidSyntax.js).
+// The webview (media/mermaidEditor.js) owns all DOM and insertion.
+//
+// Exposed as a UMD-style module: a global `MermaidCompletions` in the
+// webview, `require`-able in tests.
+(function (global) {
+  'use strict';
+
+  // ============================================================
+  // Diagram templates — the "blank page" problem
+  // ============================================================
+  // `${...}` marks the text to select after insertion so the user can type
+  // straight over it (see applyPlaceholders below).
+  const TEMPLATES = [
+    {
+      id: 'flowchart',
+      label: 'Flowchart',
+      description: 'Boxes and arrows, top-down',
+      body:
+        'flowchart TD\n' +
+        '    A[${Start}] --> B{Decision?}\n' +
+        '    B -->|Yes| C[Do the thing]\n' +
+        '    B -->|No| D[Skip it]\n' +
+        '    C --> E[Done]\n' +
+        '    D --> E\n',
+    },
+    {
+      id: 'sequence',
+      label: 'Sequence diagram',
+      description: 'Interactions between participants over time',
+      body:
+        'sequenceDiagram\n' +
+        '    participant ${Client}\n' +
+        '    participant Server\n' +
+        '    Client->>Server: Request\n' +
+        '    Server-->>Client: Response\n',
+    },
+    {
+      id: 'class',
+      label: 'Class diagram',
+      description: 'Types, fields and relationships',
+      body:
+        'classDiagram\n' +
+        '    class ${Animal} {\n' +
+        '        +String name\n' +
+        '        +move()\n' +
+        '    }\n' +
+        '    Animal <|-- Dog\n',
+    },
+    {
+      id: 'state',
+      label: 'State diagram',
+      description: 'States and the transitions between them',
+      body:
+        'stateDiagram-v2\n' +
+        '    [*] --> ${Idle}\n' +
+        '    Idle --> Running: start\n' +
+        '    Running --> Idle: stop\n' +
+        '    Running --> [*]: exit\n',
+    },
+    {
+      id: 'er',
+      label: 'Entity relationship',
+      description: 'Entities, keys and cardinality',
+      body:
+        'erDiagram\n' +
+        '    ${CUSTOMER} ||--o{ ORDER : places\n' +
+        '    ORDER ||--|{ LINE_ITEM : contains\n' +
+        '    CUSTOMER {\n' +
+        '        string name\n' +
+        '        string email\n' +
+        '    }\n',
+    },
+    {
+      id: 'gantt',
+      label: 'Gantt chart',
+      description: 'Schedule with sections and tasks',
+      body:
+        'gantt\n' +
+        '    title ${Project plan}\n' +
+        '    dateFormat YYYY-MM-DD\n' +
+        '    section Design\n' +
+        '        Research      :a1, 2026-01-01, 7d\n' +
+        '        Wireframes    :after a1, 5d\n' +
+        '    section Build\n' +
+        '        Implementation:2026-01-15, 14d\n',
+    },
+    {
+      id: 'pie',
+      label: 'Pie chart',
+      description: 'Proportions of a whole',
+      body:
+        'pie title ${Distribution}\n' +
+        '    "First"  : 45\n' +
+        '    "Second" : 30\n' +
+        '    "Third"  : 25\n',
+    },
+    {
+      id: 'mindmap',
+      label: 'Mind map',
+      description: 'Hierarchical idea tree',
+      body:
+        'mindmap\n' +
+        '  root((${Central idea}))\n' +
+        '    Branch one\n' +
+        '      Detail\n' +
+        '    Branch two\n',
+    },
+  ];
+
+  // ============================================================
+  // Snippet palette — context-aware by diagram type
+  // ============================================================
+  const FLOWCHART_SNIPPETS = [
+    { label: 'Box', title: 'Rectangular node', body: '${A}[Label]' },
+    { label: 'Rounded', title: 'Rounded node', body: '${A}(Label)' },
+    { label: 'Stadium', title: 'Stadium-shaped node', body: '${A}([Label])' },
+    { label: 'Circle', title: 'Circular node', body: '${A}((Label))' },
+    { label: 'Diamond', title: 'Decision node', body: '${A}{Label}' },
+    { label: 'Hexagon', title: 'Hexagonal node', body: '${A}{{Label}}' },
+    { label: 'Database', title: 'Cylinder node', body: '${A}[(Database)]' },
+    { label: 'Arrow', title: 'Arrow link', body: ' --> ' },
+    { label: 'Open', title: 'Open link (no arrowhead)', body: ' --- ' },
+    { label: 'Dotted', title: 'Dotted link', body: ' -.-> ' },
+    { label: 'Thick', title: 'Thick link', body: ' ==> ' },
+    { label: 'Labelled', title: 'Link with a label', body: ' -->|${label}| ' },
+    { label: 'Subgraph', title: 'Grouped section', body: 'subgraph ${Name}\n    \nend\n' },
+  ];
+
+  const SEQUENCE_SNIPPETS = [
+    { label: 'Participant', title: 'Declare a participant', body: 'participant ${Name}\n' },
+    { label: 'Actor', title: 'Declare an actor', body: 'actor ${Name}\n' },
+    { label: 'Message', title: 'Solid arrow message', body: '${A}->>B: Message\n' },
+    { label: 'Reply', title: 'Dashed reply', body: '${B}-->>A: Reply\n' },
+    { label: 'Activate', title: 'Activation block', body: 'activate ${A}\n\ndeactivate A\n' },
+    { label: 'Note', title: 'Note over participants', body: 'Note over ${A},B: Text\n' },
+    { label: 'Loop', title: 'Loop block', body: 'loop ${Every minute}\n    \nend\n' },
+    { label: 'Alt', title: 'Alternative paths', body: 'alt ${Condition}\n    \nelse Otherwise\n    \nend\n' },
+    { label: 'Opt', title: 'Optional block', body: 'opt ${Condition}\n    \nend\n' },
+    { label: 'Par', title: 'Parallel block', body: 'par ${Branch one}\n    \nand Branch two\n    \nend\n' },
+  ];
+
+  const CLASS_SNIPPETS = [
+    { label: 'Class', title: 'Class with members', body: 'class ${Name} {\n    +String field\n    +method()\n}\n' },
+    { label: 'Inherit', title: 'Inheritance', body: '${Base} <|-- Derived\n' },
+    { label: 'Compose', title: 'Composition', body: '${Whole} *-- Part\n' },
+    { label: 'Aggregate', title: 'Aggregation', body: '${Whole} o-- Part\n' },
+    { label: 'Associate', title: 'Association', body: '${A} --> B\n' },
+  ];
+
+  const STATE_SNIPPETS = [
+    { label: 'Start', title: 'Initial state', body: '[*] --> ${State}\n' },
+    { label: 'End', title: 'Final state', body: '${State} --> [*]\n' },
+    { label: 'Transition', title: 'Labelled transition', body: '${A} --> B: event\n' },
+    { label: 'Composite', title: 'Nested state', body: 'state ${Name} {\n    [*] --> Inner\n}\n' },
+    { label: 'Choice', title: 'Choice pseudo-state', body: 'state ${choice} <<choice>>\n' },
+  ];
+
+  const ER_SNIPPETS = [
+    { label: 'Relation', title: 'One-to-many relationship', body: '${A} ||--o{ B : label\n' },
+    { label: 'Entity', title: 'Entity with attributes', body: '${NAME} {\n    string field\n}\n' },
+  ];
+
+  const COMMON_SNIPPETS = [
+    { label: 'Comment', title: 'Comment line', body: '%% ${note}\n' },
+    { label: 'Title', title: 'Accessible title', body: 'accTitle: ${Title}\n' },
+  ];
+
+  const SNIPPETS_BY_TYPE = {
+    flowchart: FLOWCHART_SNIPPETS,
+    sequence: SEQUENCE_SNIPPETS,
+    class: CLASS_SNIPPETS,
+    state: STATE_SNIPPETS,
+    er: ER_SNIPPETS,
+  };
+
+  /** Keywords offered by autocomplete, per diagram type. */
+  const KEYWORDS_BY_TYPE = {
+    flowchart: ['subgraph', 'end', 'direction', 'click', 'style', 'classDef', 'linkStyle'],
+    sequence: ['participant', 'actor', 'activate', 'deactivate', 'loop', 'alt', 'else',
+      'opt', 'par', 'and', 'rect', 'note', 'autonumber', 'end'],
+    class: ['class', 'click', 'style', 'classDef', 'direction', 'note'],
+    state: ['state', 'direction', 'note', 'end'],
+    er: [],
+    unknown: [],
+  };
+
+  const DIAGRAM_TYPES = [
+    'flowchart TD', 'flowchart LR', 'graph TD', 'graph LR', 'sequenceDiagram',
+    'classDiagram', 'stateDiagram-v2', 'erDiagram', 'journey', 'gantt', 'pie',
+    'gitGraph', 'mindmap', 'timeline', 'quadrantChart', 'requirementDiagram',
+  ];
+
+  const DIRECTIONS = ['TD', 'TB', 'BT', 'LR', 'RL'];
+
+  const ARROWS = ['-->', '---', '-.->', '==>', '--x', '--o', '-->|label|'];
+
+  /**
+   * Identify the diagram type from the source, so the palette and completions
+   * can be relevant. Reads the first non-blank, non-comment, non-directive
+   * line — mermaid requires the diagram type to come first.
+   *
+   * @returns {'flowchart'|'sequence'|'class'|'state'|'er'|'unknown'}
+   */
+  function detectDiagramType(source) {
+    const lines = String(source || '').split('\n');
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+      if (line.startsWith('%%')) continue; // comment or %%{init}%% directive
+      if (/^(flowchart|graph)\b/.test(line)) return 'flowchart';
+      if (/^sequenceDiagram\b/.test(line)) return 'sequence';
+      if (/^classDiagram\b/.test(line)) return 'class';
+      if (/^stateDiagram(-v2)?\b/.test(line)) return 'state';
+      if (/^erDiagram\b/.test(line)) return 'er';
+      return 'unknown';
+    }
+    return 'unknown';
+  }
+
+  /** Snippet palette appropriate to the current diagram type. */
+  function getSnippets(source) {
+    const type = detectDiagramType(source);
+    return (SNIPPETS_BY_TYPE[type] || []).concat(COMMON_SNIPPETS);
+  }
+
+  /**
+   * Scan the source for declared node/participant identifiers.
+   *
+   * This is what makes completion genuinely useful: a typo'd node id in
+   * mermaid doesn't error, it silently creates a new orphan node, which is
+   * the single most common authoring mistake.
+   *
+   * @returns {string[]} unique ids, in first-appearance order
+   */
+  function collectNodeIds(source) {
+    const text = String(source || '');
+    const ids = [];
+    const seen = new Set();
+    const add = (id) => {
+      if (!id || seen.has(id)) return;
+      // Filter out mermaid's own keywords so `end`/`subgraph` aren't offered
+      // as if they were nodes.
+      if (RESERVED.has(id)) return;
+      seen.add(id);
+      ids.push(id);
+    };
+
+    const lines = text.split('\n');
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line || line.startsWith('%%')) continue;
+
+      // sequence: `participant Foo` / `actor Foo` (optionally `as Alias`)
+      const participant = /^(?:participant|actor)\s+([A-Za-z0-9_-]+)/.exec(line);
+      if (participant) { add(participant[1]); continue; }
+
+      // class: `class Foo {`
+      const cls = /^class\s+([A-Za-z0-9_-]+)/.exec(line);
+      if (cls) { add(cls[1]); continue; }
+
+      // subgraph: `subgraph Foo` — a valid link target in flowcharts
+      const sub = /^subgraph\s+([A-Za-z0-9_-]+)/.exec(line);
+      if (sub) { add(sub[1]); continue; }
+
+      // flowchart node declarations: an id immediately followed by a shape
+      // bracket, e.g. A[Label], B(Label), C{Label}, D((Label)).
+      const shapeRe = /(^|[\s>|-])([A-Za-z_][A-Za-z0-9_-]*)\s*[[({]/g;
+      let m;
+      while ((m = shapeRe.exec(line)) !== null) add(m[2]);
+
+      // Bare ids either side of a link operator, e.g. `A --> B`.
+      const linkRe = /([A-Za-z_][A-Za-z0-9_-]*)\s*(?:--+>?|-\.->|==+>|--[xo]|->>|-->>)\s*([A-Za-z_][A-Za-z0-9_-]*)?/g;
+      while ((m = linkRe.exec(line)) !== null) {
+        add(m[1]);
+        if (m[2]) add(m[2]);
+      }
+    }
+    return ids;
+  }
+
+  const RESERVED = new Set([
+    'graph', 'flowchart', 'sequenceDiagram', 'classDiagram', 'stateDiagram',
+    'erDiagram', 'journey', 'gantt', 'pie', 'gitGraph', 'mindmap', 'timeline',
+    'subgraph', 'end', 'participant', 'actor', 'class', 'state', 'note', 'loop',
+    'alt', 'else', 'opt', 'par', 'and', 'rect', 'activate', 'deactivate',
+    'autonumber', 'title', 'section', 'click', 'style', 'classDef', 'linkStyle',
+    'direction', 'accTitle', 'accDescr',
+    'TD', 'TB', 'BT', 'LR', 'RL',
+  ]);
+
+  /**
+   * Work out what to offer at the caret.
+   *
+   * @param {string} source full document text
+   * @param {number} caret  caret offset into `source`
+   * @returns {{items: Array<{label:string,detail?:string,kind:string}>, prefix: string, replaceFrom: number}}
+   */
+  function getCompletions(source, caret) {
+    const text = String(source || '');
+    const pos = Math.max(0, Math.min(caret, text.length));
+    const before = text.slice(0, pos);
+    const lineStart = before.lastIndexOf('\n') + 1;
+    const lineSoFar = before.slice(lineStart);
+
+    // The word being typed (letters/digits/_/- only), which is what a
+    // selection replaces.
+    const wordMatch = /([A-Za-z0-9_-]*)$/.exec(lineSoFar);
+    const prefix = wordMatch ? wordMatch[1] : '';
+    const replaceFrom = pos - prefix.length;
+
+    const type = detectDiagramType(text);
+    const isFirstMeaningfulLine = !/(^|\n)\s*(?!%%)\S/.test(before.slice(0, lineStart));
+
+    let candidates = [];
+
+    // Direction is checked BEFORE the first-line case: `flowchart ` is still
+    // the first meaningful line, but at that caret the useful suggestion is a
+    // direction, not another diagram type.
+    if (/(?:^|\s)(?:graph|flowchart)\s+[A-Za-z]*$/.test(lineSoFar)) {
+      candidates = DIRECTIONS.map((d) => ({ label: d, kind: 'direction', detail: 'direction' }));
+    } else if (isFirstMeaningfulLine) {
+      // Nothing declared yet — offer diagram types.
+      candidates = DIAGRAM_TYPES.map((d) => ({ label: d, kind: 'diagram', detail: 'diagram type' }));
+    } else if (endsWithLinkOperator(lineSoFar)) {
+      // Right after an arrow — the target node is what's wanted here.
+      candidates = collectNodeIds(text).map((id) => ({ label: id, kind: 'node', detail: 'node' }));
+    } else {
+      // General position: node ids first (most useful), then keywords, then
+      // arrows when the line already has a node on it.
+      candidates = collectNodeIds(text).map((id) => ({ label: id, kind: 'node', detail: 'node' }));
+      for (const kw of KEYWORDS_BY_TYPE[type] || []) {
+        candidates.push({ label: kw, kind: 'keyword', detail: 'keyword' });
+      }
+      if (type === 'flowchart' && /[A-Za-z0-9_\])}]\s*$/.test(lineSoFar)) {
+        for (const a of ARROWS) candidates.push({ label: a, kind: 'arrow', detail: 'link' });
+      }
+    }
+
+    const lower = prefix.toLowerCase();
+    const items = prefix
+      ? candidates.filter((c) => c.label.toLowerCase().startsWith(lower) && c.label !== prefix)
+      : candidates;
+
+    return { items: items.slice(0, 30), prefix, replaceFrom };
+  }
+
+  /** True if the text ends with a mermaid link/arrow operator (+ optional space). */
+  function endsWithLinkOperator(text) {
+    return /(?:--+>?|-\.->|==+>|--[xo]|->>|-->>|\|)\s*$/.test(text);
+  }
+
+  /**
+   * Split a snippet body into the text to insert and the range to select.
+   * `${...}` marks the placeholder; the braces are removed.
+   *
+   * @returns {{text: string, selectStart: number, selectEnd: number}}
+   */
+  function applyPlaceholders(body) {
+    const src = String(body || '');
+    const match = /\$\{([^}]*)\}/.exec(src);
+    if (!match) {
+      return { text: src, selectStart: src.length, selectEnd: src.length };
+    }
+    const text = src.slice(0, match.index) + match[1] + src.slice(match.index + match[0].length);
+    return {
+      text,
+      selectStart: match.index,
+      selectEnd: match.index + match[1].length,
+    };
+  }
+
+  /**
+   * Indentation to reuse when inserting on a fresh line, so snippets land
+   * aligned with the surrounding block.
+   */
+  function currentIndent(source, caret) {
+    const text = String(source || '');
+    const pos = Math.max(0, Math.min(caret, text.length));
+    const lineStart = text.lastIndexOf('\n', pos - 1) + 1;
+    const line = text.slice(lineStart, pos);
+    const m = /^[ \t]*/.exec(line);
+    return m ? m[0] : '';
+  }
+
+  const api = {
+    TEMPLATES,
+    detectDiagramType,
+    getSnippets,
+    collectNodeIds,
+    getCompletions,
+    applyPlaceholders,
+    currentIndent,
+    endsWithLinkOperator,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    global.MermaidCompletions = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/media/mermaidEditor.css
+++ b/media/mermaidEditor.css
@@ -46,6 +46,9 @@ html, body {
 .mmd-editor-pane {
   flex: 1;
   display: flex;
+  /* Column, so the source toolbar stacks ABOVE the editor. Without this the
+     toolbar becomes a row-sibling and squeezes the text into a sliver. */
+  flex-direction: column;
   overflow: hidden;
   min-width: 0;
 }
@@ -54,7 +57,10 @@ html, body {
   position: relative;
   flex: 1;
   min-width: 0;
-  height: 100%;
+  /* NOT height:100% — the pane is now a flex column containing the toolbar
+     too, so a fixed 100% would overflow by the toolbar's height. `flex: 1`
+     plus min-height:0 lets it take exactly the remaining space. */
+  min-height: 0;
 }
 
 /* ---------------------------------------------
@@ -371,4 +377,157 @@ body.vscode-light .mmd-line.mmd-error-line {
 
 .brand-button svg {
   display: block;
+}
+
+/* =============================================
+   Source-pane toolbox (templates + snippets)
+   ============================================= */
+.mmd-source-toolbar {
+  flex-shrink: 0;
+}
+
+.mmd-snippets {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  /* Wrap rather than scroll: with ~15 snippets, discoverability beats
+     saving a row of vertical space. */
+  flex-wrap: wrap;
+}
+
+.mmd-snippets button {
+  background: var(--button-bg);
+  color: var(--button-fg);
+  border: none;
+  border-radius: 3px;
+  padding: 3px 8px;
+  cursor: pointer;
+  font-family: var(--preview-font-family);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.mmd-snippets button:hover {
+  background: var(--button-hover-bg);
+}
+
+.mmd-snippets button:focus-visible,
+.mmd-source-toolbar button:focus-visible {
+  outline: 1px solid var(--focus-border);
+  outline-offset: 1px;
+}
+
+/* =============================================
+   Template gallery menu
+   ============================================= */
+.mmd-menu {
+  position: fixed;
+  z-index: 100;
+  min-width: 240px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--vscode-editorWidget-background, #252526);
+  border: 1px solid var(--vscode-editorWidget-border, #454545);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  padding: 4px;
+}
+
+.mmd-menu-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  padding: 6px 8px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--preview-font-family);
+}
+
+.mmd-menu-item:hover,
+.mmd-menu-item:focus-visible {
+  background: var(--vscode-list-hoverBackground, #2a2d2e);
+  outline: none;
+}
+
+.mmd-menu-label {
+  color: var(--editor-fg);
+  font-size: 12px;
+}
+
+.mmd-menu-desc {
+  color: var(--vscode-descriptionForeground, #999);
+  font-size: 11px;
+}
+
+/* =============================================
+   Completion overlay
+   ============================================= */
+.mmd-autocomplete {
+  position: fixed;
+  z-index: 100;
+  min-width: 200px;
+  max-width: 260px;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--vscode-editorWidget-background, #252526);
+  border: 1px solid var(--vscode-editorWidget-border, #454545);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  padding: 2px;
+}
+
+.mmd-autocomplete-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: var(--font-family);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.mmd-autocomplete-item.selected,
+.mmd-autocomplete-item:hover {
+  background: var(--vscode-list-activeSelectionBackground, #04395e);
+}
+
+.mmd-autocomplete-kind {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  border-radius: 2px;
+  font-size: 9px;
+  font-weight: 700;
+  color: #fff;
+  background: #6e7681;
+}
+
+.mmd-autocomplete-kind.kind-node { background: #4e9a5f; }
+.mmd-autocomplete-kind.kind-keyword { background: #9a5fa8; }
+.mmd-autocomplete-kind.kind-diagram { background: #3c7fb1; }
+.mmd-autocomplete-kind.kind-direction { background: #3f8f88; }
+.mmd-autocomplete-kind.kind-arrow { background: #a8763f; }
+
+.mmd-autocomplete-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--editor-fg);
+}
+
+.mmd-autocomplete-detail {
+  color: var(--vscode-descriptionForeground, #999);
+  font-size: 10px;
+  flex-shrink: 0;
 }

--- a/media/mermaidEditor.js
+++ b/media/mermaidEditor.js
@@ -276,6 +276,15 @@
       exportPng(message.theme === 'light' ? 'light' : 'dark');
       return;
     }
+    if (message.type === 'templateReplaceConfirmed') {
+      const body = pendingTemplateBody;
+      pendingTemplateBody = null;
+      if (!body || !message.confirmed) return;
+      textarea.focus();
+      textarea.select(); // replace the whole document
+      insertSnippet(body);
+      return;
+    }
     if (message.type === 'update') {
       const text = normalizeEol(message.text);
       const isEcho = text === textarea.value || text === lastSentEditText;
@@ -736,7 +745,6 @@
   // @ts-ignore - MermaidCompletions loaded globally from mermaidCompletions.js
   const completions = typeof MermaidCompletions !== 'undefined' ? MermaidCompletions : null;
 
-  const sourceToolbar = document.getElementById('mmd-source-toolbar');
   const snippetsBar = document.getElementById('mmd-snippets');
   const btnTemplate = document.getElementById('mmd-template');
 
@@ -820,6 +828,8 @@
 
   // --- Template gallery -------------------------------------------------
   let templateMenu = null;
+  /** Template awaiting the host's replace-confirmation reply. */
+  let pendingTemplateBody = null;
 
   function closeTemplateMenu() {
     if (templateMenu) {
@@ -859,17 +869,18 @@
 
       item.addEventListener('click', () => {
         closeTemplateMenu();
-        const existing = textarea.value.trim();
-        if (existing) {
-          // Replacing a non-empty document silently would destroy work.
-          const replace = confirm(
-            'Replace the current diagram with the ' + template.label + ' template?'
-          );
-          if (!replace) return;
-          textarea.select();
-        } else {
-          textarea.focus();
+        if (textarea.value.trim()) {
+          // Replacing a non-empty document silently would destroy work, so
+          // confirm first — but via the host, because webviews are sandboxed
+          // without allow-modals: confirm()/alert() are blocked there (the
+          // same restriction that stops window.print(), see the Print
+          // handler above). A blocked confirm() returns false, which would
+          // make templates silently do nothing on any non-empty document.
+          pendingTemplateBody = template.body;
+          vscode.postMessage({ type: 'confirmTemplateReplace', label: template.label });
+          return;
         }
+        textarea.focus();
         insertSnippet(template.body);
       });
       templateMenu.appendChild(item);

--- a/media/mermaidEditor.js
+++ b/media/mermaidEditor.js
@@ -300,6 +300,8 @@
       // overlay must be refreshed explicitly here.
       updateHighlight(text);
       highlightPre.scrollTop = textarea.scrollTop;
+      refreshSnippetPalette();
+      autocomplete.hide(); // the document changed underneath any open list
       renderDiagram(text);
     }
   });
@@ -311,6 +313,8 @@
     const text = textarea.value;
 
     updateHighlight(text);
+    refreshSnippetPalette();
+    refreshCompletions();
 
     clearTimeout(renderDebounce);
     renderDebounce = setTimeout(() => renderDiagram(text), 300);
@@ -727,6 +731,345 @@
   });
 
   // ================================================
+  // Authoring assistance: toolbox palette + completions
+  // ================================================
+  // @ts-ignore - MermaidCompletions loaded globally from mermaidCompletions.js
+  const completions = typeof MermaidCompletions !== 'undefined' ? MermaidCompletions : null;
+
+  const sourceToolbar = document.getElementById('mmd-source-toolbar');
+  const snippetsBar = document.getElementById('mmd-snippets');
+  const btnTemplate = document.getElementById('mmd-template');
+
+  /**
+   * Insert text at the caret, replacing any selection.
+   *
+   * Uses execCommand('insertText') so the browser keeps its native undo
+   * stack and fires a real `input` event — which is what drives the existing
+   * highlight refresh, render debounce and document-sync path. Assigning
+   * textarea.value directly would break undo AND fire no event, silently
+   * desyncing the document.
+   *
+   * @param {string} text
+   * @param {number} [selectStart] offset within `text` to select from
+   * @param {number} [selectEnd]
+   * @param {number} [replaceFrom] absolute offset to replace from (for completions)
+   */
+  function insertAtCaret(text, selectStart, selectEnd, replaceFrom) {
+    textarea.focus();
+    if (typeof replaceFrom === 'number' && replaceFrom < textarea.selectionStart) {
+      textarea.setSelectionRange(replaceFrom, textarea.selectionEnd);
+    }
+    const base = Math.min(textarea.selectionStart, textarea.selectionEnd);
+    let inserted = false;
+    try {
+      inserted = document.execCommand('insertText', false, text);
+    } catch (_) {
+      inserted = false;
+    }
+    if (!inserted) {
+      // execCommand is deprecated and could stop working; fall back to a
+      // manual splice plus a synthetic input event so sync still happens.
+      const start = base;
+      const end = Math.max(textarea.selectionStart, textarea.selectionEnd);
+      textarea.value = textarea.value.slice(0, start) + text + textarea.value.slice(end);
+      textarea.selectionStart = textarea.selectionEnd = start + text.length;
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    if (typeof selectStart === 'number' && typeof selectEnd === 'number') {
+      textarea.setSelectionRange(base + selectStart, base + selectEnd);
+    }
+  }
+
+  /** Insert a snippet/template body, honouring its ${placeholder} and indent. */
+  function insertSnippet(body) {
+    if (!completions) return;
+    const caret = textarea.selectionStart;
+    const value = textarea.value;
+    let text = body;
+
+    // A multi-line snippet dropped mid-line would produce broken syntax —
+    // start it on its own line, indented to match the current one.
+    if (body.indexOf('\n') !== -1) {
+      const indent = completions.currentIndent(value, caret);
+      const atLineStart = caret === 0 || value[caret - 1] === '\n';
+      text = (atLineStart ? '' : '\n') + body.split('\n').join('\n' + indent);
+      // Trim the indent the join added to the trailing empty line.
+      text = text.replace(/\n[ \t]+$/, '\n');
+    }
+
+    const applied = completions.applyPlaceholders(text);
+    insertAtCaret(applied.text, applied.selectStart, applied.selectEnd);
+  }
+
+  /** Rebuild the snippet palette for the current diagram type. */
+  let renderedSnippetType = null;
+  function refreshSnippetPalette() {
+    if (!completions || !snippetsBar) return;
+    const type = completions.detectDiagramType(textarea.value);
+    if (type === renderedSnippetType) return; // avoid needless DOM churn per keystroke
+    renderedSnippetType = type;
+    snippetsBar.textContent = '';
+    for (const snippet of completions.getSnippets(textarea.value)) {
+      const btn = document.createElement('button');
+      btn.textContent = snippet.label;
+      btn.title = snippet.title;
+      btn.addEventListener('click', () => insertSnippet(snippet.body));
+      snippetsBar.appendChild(btn);
+    }
+  }
+
+  // --- Template gallery -------------------------------------------------
+  let templateMenu = null;
+
+  function closeTemplateMenu() {
+    if (templateMenu) {
+      templateMenu.remove();
+      templateMenu = null;
+      document.removeEventListener('mousedown', onTemplateOutsideClick, true);
+    }
+  }
+
+  function onTemplateOutsideClick(e) {
+    if (templateMenu && !templateMenu.contains(e.target) && e.target !== btnTemplate) {
+      closeTemplateMenu();
+    }
+  }
+
+  function openTemplateMenu() {
+    if (!completions || !btnTemplate) return;
+    if (templateMenu) { closeTemplateMenu(); return; }
+
+    templateMenu = document.createElement('div');
+    templateMenu.className = 'mmd-menu';
+    templateMenu.setAttribute('role', 'menu');
+
+    for (const template of completions.TEMPLATES) {
+      const item = document.createElement('button');
+      item.className = 'mmd-menu-item';
+      item.setAttribute('role', 'menuitem');
+
+      const label = document.createElement('span');
+      label.className = 'mmd-menu-label';
+      label.textContent = template.label;
+      const desc = document.createElement('span');
+      desc.className = 'mmd-menu-desc';
+      desc.textContent = template.description;
+      item.appendChild(label);
+      item.appendChild(desc);
+
+      item.addEventListener('click', () => {
+        closeTemplateMenu();
+        const existing = textarea.value.trim();
+        if (existing) {
+          // Replacing a non-empty document silently would destroy work.
+          const replace = confirm(
+            'Replace the current diagram with the ' + template.label + ' template?'
+          );
+          if (!replace) return;
+          textarea.select();
+        } else {
+          textarea.focus();
+        }
+        insertSnippet(template.body);
+      });
+      templateMenu.appendChild(item);
+    }
+
+    const rect = btnTemplate.getBoundingClientRect();
+    templateMenu.style.top = rect.bottom + 4 + 'px';
+    templateMenu.style.left = rect.left + 'px';
+    document.body.appendChild(templateMenu);
+    // Capture phase, so the click that opened the menu doesn't immediately
+    // close it.
+    setTimeout(() => document.addEventListener('mousedown', onTemplateOutsideClick, true), 0);
+  }
+
+  btnTemplate?.addEventListener('click', openTemplateMenu);
+
+  // --- Completion overlay -----------------------------------------------
+  // VS Code's CompletionItemProvider only applies to real TextEditors, not a
+  // textarea in a webview, so this is a custom overlay — the same approach
+  // the markdown editor uses for [[wikilink]] autocomplete.
+  const autocomplete = (() => {
+    let isOpen = false;
+    let items = [];
+    let selectedIndex = 0;
+    let replaceFrom = 0;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'mmd-autocomplete';
+    overlay.style.display = 'none';
+    document.body.appendChild(overlay);
+
+    overlay.addEventListener('mousedown', (e) => {
+      const el = e.target.closest('.mmd-autocomplete-item');
+      if (!el) return;
+      e.preventDefault(); // keep focus in the textarea
+      selectedIndex = Number(el.dataset.index);
+      confirm();
+    });
+
+    function render() {
+      overlay.textContent = '';
+      items.forEach((item, i) => {
+        const row = document.createElement('div');
+        row.className = 'mmd-autocomplete-item' + (i === selectedIndex ? ' selected' : '');
+        row.dataset.index = String(i);
+
+        const kind = document.createElement('span');
+        kind.className = 'mmd-autocomplete-kind kind-' + item.kind;
+        kind.textContent = item.kind.charAt(0).toUpperCase();
+        const label = document.createElement('span');
+        label.className = 'mmd-autocomplete-label';
+        label.textContent = item.label;
+        const detail = document.createElement('span');
+        detail.className = 'mmd-autocomplete-detail';
+        detail.textContent = item.detail || '';
+
+        row.appendChild(kind);
+        row.appendChild(label);
+        row.appendChild(detail);
+        overlay.appendChild(row);
+      });
+    }
+
+    /** Position the overlay under the caret, approximated from line/column. */
+    function position() {
+      const before = textarea.value.slice(0, textarea.selectionStart);
+      const lines = before.split('\n');
+      const lineNum = lines.length - 1;
+      const col = lines[lines.length - 1].length;
+
+      const rect = textarea.getBoundingClientRect();
+      const style = getComputedStyle(textarea);
+      const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.6;
+      const padTop = parseFloat(style.paddingTop) || 0;
+      const padLeft = parseFloat(style.paddingLeft) || 0;
+      // Monospace, so a single character's width is representative.
+      const charWidth = measureCharWidth(style);
+
+      let top = rect.top + padTop + (lineNum + 1) * lineHeight - textarea.scrollTop;
+      let left = rect.left + padLeft + col * charWidth - textarea.scrollLeft;
+
+      // Clamp to the SOURCE PANE, not the window. Clamping to the window
+      // lets a long line push the list over the preview pane, where it
+      // covers the toolbar and swallows clicks meant for it.
+      const OVERLAY_W = 260;
+      const OVERLAY_H = 220;
+      const viewH = document.documentElement.clientHeight;
+      const maxLeft = rect.right - OVERLAY_W;
+      if (left > maxLeft) left = maxLeft;
+      if (left < rect.left) left = rect.left;
+      if (top + OVERLAY_H > viewH) top = top - lineHeight - OVERLAY_H;
+
+      overlay.style.top = Math.max(0, top) + 'px';
+      overlay.style.left = Math.max(0, left) + 'px';
+    }
+
+    let cachedCharWidth = 0;
+    let cachedFont = '';
+    function measureCharWidth(style) {
+      const font = style.font || style.fontSize + ' ' + style.fontFamily;
+      if (font === cachedFont && cachedCharWidth) return cachedCharWidth;
+      const probe = document.createElement('span');
+      probe.style.position = 'absolute';
+      probe.style.visibility = 'hidden';
+      probe.style.whiteSpace = 'pre';
+      probe.style.font = font;
+      probe.textContent = '0'.repeat(50);
+      document.body.appendChild(probe);
+      cachedCharWidth = probe.getBoundingClientRect().width / 50;
+      probe.remove();
+      cachedFont = font;
+      return cachedCharWidth;
+    }
+
+    function show(result) {
+      items = result.items;
+      replaceFrom = result.replaceFrom;
+      selectedIndex = 0;
+      isOpen = true;
+      render();
+      position();
+      overlay.style.display = 'block';
+    }
+
+    function hide() {
+      isOpen = false;
+      items = [];
+      overlay.style.display = 'none';
+    }
+
+    function move(delta) {
+      if (!items.length) return;
+      selectedIndex = (selectedIndex + delta + items.length) % items.length;
+      render();
+      const sel = overlay.querySelector('.mmd-autocomplete-item.selected');
+      if (sel) sel.scrollIntoView({ block: 'nearest' });
+    }
+
+    function confirm() {
+      if (!items.length) { hide(); return; }
+      const item = items[selectedIndex];
+      const caret = textarea.selectionStart;
+      hide();
+      insertAtCaret(item.label, undefined, undefined, replaceFrom < caret ? replaceFrom : undefined);
+    }
+
+    return {
+      get isOpen() { return isOpen; },
+      show, hide, move, confirm,
+      /** Re-anchor to the caret, e.g. after the textarea scrolls. */
+      reposition() { if (isOpen) position(); },
+    };
+  })();
+
+  /** Recompute completions for the current caret; hide when there's nothing. */
+  function refreshCompletions() {
+    if (!completions) return;
+    // Only offer completions for a collapsed caret — during a selection the
+    // user is doing something else.
+    if (textarea.selectionStart !== textarea.selectionEnd) {
+      autocomplete.hide();
+      return;
+    }
+    const result = completions.getCompletions(textarea.value, textarea.selectionStart);
+    if (!result.items.length) {
+      autocomplete.hide();
+      return;
+    }
+    autocomplete.show(result);
+  }
+
+  textarea.addEventListener('keydown', (e) => {
+    if (autocomplete.isOpen) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); autocomplete.move(1); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); autocomplete.move(-1); return; }
+      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); autocomplete.confirm(); return; }
+      if (e.key === 'Escape') { e.preventDefault(); autocomplete.hide(); return; }
+    }
+    // Ctrl/Cmd+Space explicitly requests completions.
+    if ((e.ctrlKey || e.metaKey) && e.key === ' ') {
+      e.preventDefault();
+      refreshCompletions();
+    }
+  });
+
+  textarea.addEventListener('blur', () => autocomplete.hide());
+  // Any click outside the textarea dismisses the list, so it can never sit
+  // over other UI swallowing clicks. Capture phase, so it runs before the
+  // click reaches whatever was aimed at.
+  document.addEventListener('mousedown', (e) => {
+    if (!autocomplete.isOpen) return;
+    if (e.target === textarea || (e.target.closest && e.target.closest('.mmd-autocomplete'))) return;
+    autocomplete.hide();
+  }, true);
+  // Follow the caret rather than dismissing: typing itself scrolls the
+  // textarea to keep the caret visible, so hiding here would close the list
+  // the instant it opened.
+  textarea.addEventListener('scroll', () => autocomplete.reposition());
+
+  // ================================================
   // Draggable divider for pane resizing
   // ================================================
   let isDragging = false;
@@ -775,6 +1118,7 @@
 
   setExportButtonsEnabled(false);
   applyTransform();
+  refreshSnippetPalette();
   vscode.postMessage({ type: 'ready' });
   // Initial render happens when the first 'update' message arrives.
 })();

--- a/src/mermaidEditorProvider.ts
+++ b/src/mermaidEditorProvider.ts
@@ -302,6 +302,9 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
     const syntaxUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this.context.extensionUri, 'media', 'mermaidSyntax.js')
     );
+    const completionsUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.context.extensionUri, 'media', 'mermaidCompletions.js')
+    );
 
     return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -320,6 +323,11 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
 <body>
   <div class="mmd-container" id="mmd-container">
     <div class="mmd-editor-pane" id="mmd-editor-pane">
+      <div class="mmd-toolbar mmd-source-toolbar" id="mmd-source-toolbar">
+        <button id="mmd-template" title="Insert a starter diagram">Template</button>
+        <span class="mmd-toolbar-separator"></span>
+        <div class="mmd-snippets" id="mmd-snippets"></div>
+      </div>
       <div class="mmd-editor-stack" id="mmd-editor-stack">
         <pre class="mmd-highlight" id="mmd-highlight" aria-hidden="true"><code id="mmd-highlight-code"></code></pre>
         <textarea id="mmd-input"
@@ -350,6 +358,7 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
   </div>
   <script nonce="${nonce}" src="${mermaidUri}?v=${cacheBust}"></script>
   <script nonce="${nonce}" src="${syntaxUri}?v=${cacheBust}"></script>
+  <script nonce="${nonce}" src="${completionsUri}?v=${cacheBust}"></script>
   <script nonce="${nonce}" src="${scriptUri}?v=${cacheBust}"></script>
 </body>
 </html>`;

--- a/src/mermaidEditorProvider.ts
+++ b/src/mermaidEditorProvider.ts
@@ -247,6 +247,19 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
             await showAboutDialog(this.context);
             return;
 
+          case 'confirmTemplateReplace': {
+            const answer = await vscode.window.showWarningMessage(
+              `Replace the current diagram with the ${message.label} template?`,
+              { modal: true, detail: 'The existing diagram source will be overwritten. This can be undone.' },
+              'Replace'
+            );
+            webviewPanel.webview.postMessage({
+              type: 'templateReplaceConfirmed',
+              confirmed: answer === 'Replace',
+            });
+            return;
+          }
+
           case 'print': {
             // window.print() is suppressed inside VS Code's sandboxed webview
             // iframes (no allow-modals), and fails silently. Write a

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,7 +172,9 @@ export type MermaidEditorToWebviewMessage =
   | { type: 'update'; text: string }
   | { type: 'editAck' }
   /** Result of the export-theme QuickPick; the webview then rasterizes. */
-  | { type: 'exportPngTheme'; theme: 'light' | 'dark' };
+  | { type: 'exportPngTheme'; theme: 'light' | 'dark' }
+  /** Result of the "replace the document with a template?" confirmation. */
+  | { type: 'templateReplaceConfirmed'; confirmed: boolean };
 
 /** Messages from mermaid editor webview -> extension host */
 export type MermaidWebviewToExtensionMessage =
@@ -185,6 +187,12 @@ export type MermaidWebviewToExtensionMessage =
   | { type: 'exportError'; message: string }
   /** Toolbar brand button — show the About dialog. */
   | { type: 'showAbout' }
+  /**
+   * Ask the host to confirm replacing the document with a template.
+   * Confirmation must happen host-side: webviews are sandboxed without
+   * allow-modals, so confirm() is blocked there.
+   */
+  | { type: 'confirmTemplateReplace'; label: string }
   /**
    * Serialized SVG to print. The host writes it to a standalone HTML file and
    * opens it externally — window.print() is suppressed inside VS Code's

--- a/tests/mermaidCompletions.test.mjs
+++ b/tests/mermaidCompletions.test.mjs
@@ -1,0 +1,253 @@
+// Unit tests for the Mermaid authoring-assistance module
+// (media/mermaidCompletions.js): diagram-type detection, the context-aware
+// snippet palette, node-id scanning, and completion suggestions.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  TEMPLATES,
+  detectDiagramType,
+  getSnippets,
+  collectNodeIds,
+  getCompletions,
+  applyPlaceholders,
+  currentIndent,
+} = require('../media/mermaidCompletions.js');
+
+/** Completion labels at a caret placed at the end of `source`. */
+function labelsAtEnd(source) {
+  return getCompletions(source, source.length).items.map((i) => i.label);
+}
+
+// ============================================================
+// Diagram type detection
+// ============================================================
+
+test('detects each supported diagram type', () => {
+  assert.strictEqual(detectDiagramType('flowchart TD\nA --> B'), 'flowchart');
+  assert.strictEqual(detectDiagramType('graph LR\nA --> B'), 'flowchart');
+  assert.strictEqual(detectDiagramType('sequenceDiagram\nA->>B: hi'), 'sequence');
+  assert.strictEqual(detectDiagramType('classDiagram\nclass Foo'), 'class');
+  assert.strictEqual(detectDiagramType('stateDiagram-v2\n[*] --> A'), 'state');
+  assert.strictEqual(detectDiagramType('stateDiagram\n[*] --> A'), 'state');
+  assert.strictEqual(detectDiagramType('erDiagram\nA ||--o{ B : x'), 'er');
+});
+
+test('detection skips blank lines, comments and init directives', () => {
+  assert.strictEqual(
+    detectDiagramType("%%{init: {'theme':'dark'}}%%\n\n%% a note\nflowchart TD\nA --> B"),
+    'flowchart'
+  );
+});
+
+test('detection returns unknown for empty or unrecognized sources', () => {
+  assert.strictEqual(detectDiagramType(''), 'unknown');
+  assert.strictEqual(detectDiagramType('\n\n  \n'), 'unknown');
+  assert.strictEqual(detectDiagramType('gantt\ntitle X'), 'unknown'); // no palette yet
+  assert.strictEqual(detectDiagramType(undefined), 'unknown');
+});
+
+// ============================================================
+// Snippet palette
+// ============================================================
+
+test('palette is context-aware by diagram type', () => {
+  const flow = getSnippets('flowchart TD\n').map((s) => s.label);
+  assert.ok(flow.includes('Diamond'), 'flowchart palette should offer node shapes');
+  assert.ok(flow.includes('Subgraph'));
+  assert.ok(!flow.includes('Participant'), 'flowchart palette should not offer sequence snippets');
+
+  const seq = getSnippets('sequenceDiagram\n').map((s) => s.label);
+  assert.ok(seq.includes('Participant'));
+  assert.ok(seq.includes('Loop'));
+  assert.ok(!seq.includes('Diamond'));
+});
+
+test('common snippets are always offered', () => {
+  for (const src of ['flowchart TD\n', 'sequenceDiagram\n', 'classDiagram\n', '']) {
+    const labels = getSnippets(src).map((s) => s.label);
+    assert.ok(labels.includes('Comment'), `Comment missing for ${JSON.stringify(src)}`);
+  }
+});
+
+test('every snippet and template has a non-empty body', () => {
+  for (const t of TEMPLATES) {
+    assert.ok(t.id && t.label && t.body.length > 0, `bad template ${t.id}`);
+  }
+  for (const src of ['flowchart TD', 'sequenceDiagram', 'classDiagram', 'stateDiagram-v2', 'erDiagram']) {
+    for (const s of getSnippets(src)) {
+      assert.ok(s.label && s.body.length > 0, `bad snippet ${s.label}`);
+    }
+  }
+});
+
+test('every template body starts with its own diagram type', () => {
+  // A template that doesn't declare a diagram type would produce an
+  // unparseable document when inserted into an empty file.
+  const expectations = {
+    flowchart: /^flowchart /, sequence: /^sequenceDiagram/, class: /^classDiagram/,
+    state: /^stateDiagram-v2/, er: /^erDiagram/, gantt: /^gantt/, pie: /^pie /,
+    mindmap: /^mindmap/,
+  };
+  for (const t of TEMPLATES) {
+    const re = expectations[t.id];
+    assert.ok(re, `no expectation registered for template ${t.id}`);
+    assert.match(applyPlaceholders(t.body).text, re, `template ${t.id}`);
+  }
+});
+
+// ============================================================
+// Placeholders
+// ============================================================
+
+test('applyPlaceholders strips the marker and selects the placeholder text', () => {
+  const r = applyPlaceholders('${A}[Label]');
+  assert.strictEqual(r.text, 'A[Label]');
+  assert.strictEqual(r.text.slice(r.selectStart, r.selectEnd), 'A');
+});
+
+test('applyPlaceholders handles a body with no placeholder', () => {
+  const r = applyPlaceholders(' --> ');
+  assert.strictEqual(r.text, ' --> ');
+  assert.strictEqual(r.selectStart, r.text.length);
+  assert.strictEqual(r.selectEnd, r.text.length);
+});
+
+test('applyPlaceholders handles multi-line bodies', () => {
+  const r = applyPlaceholders('subgraph ${Name}\n    \nend\n');
+  assert.strictEqual(r.text, 'subgraph Name\n    \nend\n');
+  assert.strictEqual(r.text.slice(r.selectStart, r.selectEnd), 'Name');
+});
+
+// ============================================================
+// Node id scanning
+// ============================================================
+
+test('collects flowchart node ids from shapes and links', () => {
+  const ids = collectNodeIds('flowchart TD\n  A[Start] --> B{Choice}\n  B --> C\n  D((Round))');
+  for (const id of ['A', 'B', 'C', 'D']) {
+    assert.ok(ids.includes(id), `missing ${id} in ${JSON.stringify(ids)}`);
+  }
+});
+
+test('collects sequence participants and actors', () => {
+  const ids = collectNodeIds('sequenceDiagram\n  participant Client\n  actor User\n  Client->>User: hi');
+  assert.ok(ids.includes('Client'));
+  assert.ok(ids.includes('User'));
+});
+
+test('collects class names and subgraph names', () => {
+  assert.ok(collectNodeIds('classDiagram\n  class Animal {\n  }\n').includes('Animal'));
+  assert.ok(collectNodeIds('flowchart TD\n  subgraph Platform\n    A --> B\n  end').includes('Platform'));
+});
+
+test('node ids exclude mermaid keywords', () => {
+  const ids = collectNodeIds('flowchart TD\n  subgraph Group\n    A --> B\n  end\n  B --> C');
+  for (const kw of ['subgraph', 'end', 'flowchart', 'TD']) {
+    assert.ok(!ids.includes(kw), `keyword ${kw} should not be a node id`);
+  }
+});
+
+test('node ids are unique and in first-appearance order', () => {
+  const ids = collectNodeIds('flowchart TD\n  B --> A\n  A --> B\n  A --> C');
+  assert.deepStrictEqual(ids, ['B', 'A', 'C']);
+});
+
+test('comment lines are not scanned for node ids', () => {
+  const ids = collectNodeIds('flowchart TD\n  %% GHOST[Not real] --> ALSOGHOST\n  A --> B');
+  assert.ok(!ids.includes('GHOST'));
+  assert.ok(!ids.includes('ALSOGHOST'));
+  assert.ok(ids.includes('A'));
+});
+
+test('node id scanning tolerates odd input without throwing', () => {
+  for (const src of ['', '   ', '\n\n', 'flowchart TD', '-->', '[[[', undefined, null]) {
+    assert.doesNotThrow(() => collectNodeIds(src));
+  }
+});
+
+// ============================================================
+// Completions
+// ============================================================
+
+test('offers diagram types on the first line', () => {
+  const labels = labelsAtEnd('');
+  assert.ok(labels.some((l) => l.startsWith('flowchart')));
+  assert.ok(labels.includes('sequenceDiagram'));
+});
+
+test('filters diagram types by the typed prefix', () => {
+  const { items, prefix } = getCompletions('seq', 3);
+  assert.strictEqual(prefix, 'seq');
+  assert.deepStrictEqual(items.map((i) => i.label), ['sequenceDiagram']);
+});
+
+test('offers directions right after graph/flowchart', () => {
+  const labels = labelsAtEnd('flowchart ');
+  assert.deepStrictEqual(labels.sort(), ['BT', 'LR', 'RL', 'TB', 'TD'].sort());
+});
+
+test('offers known node ids after an arrow — the key feature', () => {
+  const src = 'flowchart TD\n  Alpha[A] --> Beta[B]\n  Beta --> ';
+  const labels = labelsAtEnd(src);
+  assert.ok(labels.includes('Alpha'), `expected Alpha in ${JSON.stringify(labels)}`);
+  assert.ok(labels.includes('Beta'));
+  // Only nodes are relevant immediately after an arrow.
+  assert.ok(!labels.includes('subgraph'));
+});
+
+test('filters node ids by prefix after an arrow', () => {
+  const src = 'flowchart TD\n  Alpha[A] --> Beta[B]\n  Beta --> Al';
+  const { items, prefix, replaceFrom } = getCompletions(src, src.length);
+  assert.strictEqual(prefix, 'Al');
+  assert.deepStrictEqual(items.map((i) => i.label), ['Alpha']);
+  // The suggestion must replace the typed prefix, not append to it.
+  assert.strictEqual(src.slice(replaceFrom), 'Al');
+});
+
+test('offers diagram-appropriate keywords mid-document', () => {
+  const seqLabels = labelsAtEnd('sequenceDiagram\n  participant A\n  ');
+  assert.ok(seqLabels.includes('participant'));
+  assert.ok(seqLabels.includes('loop'));
+  assert.ok(!seqLabels.includes('subgraph'), 'flowchart keyword leaked into sequence diagram');
+
+  const flowLabels = labelsAtEnd('flowchart TD\n  A --> B\n  ');
+  assert.ok(flowLabels.includes('subgraph'));
+  assert.ok(!flowLabels.includes('participant'));
+});
+
+test('offers arrows after a node in a flowchart', () => {
+  const labels = labelsAtEnd('flowchart TD\n  A[Start] ');
+  assert.ok(labels.includes('-->'), `expected an arrow in ${JSON.stringify(labels)}`);
+});
+
+test('an exact match is not re-offered', () => {
+  const src = 'flowchart TD\n  Alpha[A] --> Beta[B]\n  Beta --> Alpha';
+  assert.ok(!labelsAtEnd(src).includes('Alpha'));
+});
+
+test('results are capped so the overlay cannot grow unbounded', () => {
+  let src = 'flowchart TD\n';
+  for (let i = 0; i < 100; i++) src += `  Node${i}[N${i}] --> Other${i}\n`;
+  src += '  Node0 --> ';
+  assert.ok(getCompletions(src, src.length).items.length <= 30);
+});
+
+test('getCompletions tolerates out-of-range carets', () => {
+  assert.doesNotThrow(() => getCompletions('flowchart TD', -5));
+  assert.doesNotThrow(() => getCompletions('flowchart TD', 9999));
+  assert.doesNotThrow(() => getCompletions('', 0));
+});
+
+// ============================================================
+// Indentation
+// ============================================================
+
+test('currentIndent returns the leading whitespace of the caret line', () => {
+  const src = 'flowchart TD\n    A --> B';
+  assert.strictEqual(currentIndent(src, src.length), '    ');
+  assert.strictEqual(currentIndent('flowchart TD\n', 13), '');
+  assert.strictEqual(currentIndent('\tX', 2), '\t');
+});

--- a/todo.md
+++ b/todo.md
@@ -182,3 +182,11 @@
 - [ ] Evaluate D2 (`@terrastruct/d2`, MPL-2.0) as a second diagram renderer for architecture diagrams — needs `wasm-unsafe-eval` + `worker-src blob:` CSP additions, ~8MB bundle
 - [ ] AVOID PlantUML: core is GPL. An MIT-flavoured `@plantuml/core` build exists but is very new and its MIT-ness depends on the maintainer gating GPL paths each release — unacceptable risk given the intent to keep commercial options open
 - [ ] Clickable/editable mermaid diagrams in the markdown WYSIWYG view (currently read-only by design — Turndown round-trip would mangle an editable SVG)
+
+## 2026-07-19 Mermaid authoring assistance (PR #51)
+
+- [x] `media/mermaidCompletions.js` — templates, context-aware snippet palette, node-id scanner, completion engine (UMD, unit-testable) + 28 committed tests
+- [x] Template gallery: 8 starter diagrams (flowchart, sequence, class, state, ER, gantt, pie, mindmap) with placeholder selection
+- [x] Context-aware snippet palette that follows the detected diagram type
+- [x] IntelliSense-style completion overlay: node ids after arrows (the headline feature — a typo'd id silently creates an orphan node in mermaid), diagram types, directions, keywords, arrows
+- [x] Regression gate: all 44 pre-existing Playwright checks + 66 unit tests still pass


### PR DESCRIPTION
## Summary

Makes the `.mmd` editor usable without memorising Mermaid syntax.

- **Template gallery** — 8 starter diagrams (flowchart, sequence, class, state, ER, gantt, pie, mindmap). Each inserts a *working* diagram with its first label pre-selected to type over. Replacing a non-empty document asks for confirmation first.
- **Context-aware snippet palette** — follows the detected diagram type: node shapes and link styles for flowcharts, `participant`/`loop`/`alt`/`note` for sequence diagrams, and so on. Rebuilt only when the type actually changes, not per keystroke.
- **Completion overlay** — offers **node ids after an arrow**, plus diagram types, directions, keywords and arrows.

The node-id completion is the headline feature: a typo'd node id doesn't error in Mermaid, it **silently creates an orphan node**, which is the single most common authoring mistake. Note VS Code's `CompletionItemProvider` doesn't apply to a `<textarea>` in a webview, so this is a custom overlay — modelled on the markdown editor's existing `[[wikilink]]` autocomplete.

## Design notes

Logic lives in `media/mermaidCompletions.js` with **no DOM access**, so it's directly unit testable (28 committed tests) — the same split used for `mermaidSyntax.js` and `turndownTableRules.js`. The webview owns insertion and rendering only.

All insertion goes through `document.execCommand('insertText')` so the browser's **native undo stack survives** and a real `input` event fires — the existing highlight refresh, render debounce and document sync all hang off that event. Assigning `textarea.value` directly would break undo *and* fire no event, silently desyncing the document. There's a manual-splice + synthetic-event fallback in case `execCommand` is ever removed.

## Three bugs found during verification

1. **The completion list closed the instant it opened.** The `scroll` handler hid it — and typing itself scrolls the textarea to keep the caret visible. Now repositions instead of hiding, which is better behavior anyway.
2. **The overlay could cover the preview toolbar and swallow its clicks** — it clamped to the *window* edge rather than the source pane, so a long line pushed it across. Caught by the **pre-existing feature suite**, not the new tests. Now clamped to the source pane, plus an outside-mousedown dismiss.
3. **The source toolbar squeezed the editor into a one-character-wide strip.** `.mmd-editor-pane` is `display: flex` with default *row* direction, so the new toolbar became a sibling column. This was only visible by **looking at a screenshot — all 61 automated checks passed**. Fixed with `flex-direction: column` (and `min-height: 0` on the stack instead of `height: 100%`, which would now overflow by the toolbar's height).

## Verification

- **94 unit tests** (66 existing + 28 new)
- **61 Playwright checks**: 14 behavioral regression (the sync contract — echo suppression, CRLF, in-flight edit races), 23 feature, 7 review-fix, 17 new toolbox/completions
- `check-types` and `compile` clean

The pre-existing suites were re-run as a regression gate throughout; they're what caught bug 2.

## Test plan

- [ ] Open a `.mmd` file, click **Template** → pick a diagram → confirm it inserts and renders, with the first label selected
- [ ] Confirm the snippet palette changes when you switch diagram type
- [ ] Click a snippet — confirm it inserts at the caret with its placeholder selected, and that **Ctrl+Z undoes it in one step**
- [ ] Type `A[One] --> B[Two]` then on a new line type `B --> ` — confirm node ids are offered; Enter accepts, Escape dismisses
- [ ] Type a partial id (`B --> A`) — confirm it filters and accepting *replaces* the prefix rather than appending
- [ ] Confirm the completion list never covers the preview toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)