### PR TITLE
docs: document toolbox/IntelliSense and glTF editor for 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ First stable release.
 - **Export diagrams as PNG**, with a choice of light or dark background — a light export re-renders the diagram for a white background, so it stays readable when dropped into documents and slides.
 - **Print diagrams / save as PDF** — opens the diagram in your browser, where Print and its "Save as PDF" destination work properly.
 - **Refreshed diagram styling** — softer rounded corners, a flatter and more professional palette, and cleaner typography, with proper light and dark theme support that follows your VS Code theme (including live re-render when you switch themes).
+- **Mermaid authoring help** — a **Template** gallery inserting working starter diagrams (flowchart, sequence, class, state, ER, gantt, pie, mind map), a snippet palette that changes with the diagram type you're writing, and completions offering the node IDs already in your diagram, plus diagram types, directions, keywords and arrows. The node-ID completion prevents Mermaid's most common trap: a mistyped ID doesn't error, it silently creates a stray disconnected node.
+- **glTF 3D file editor** — opening a `.gltf` file gives you the JSON source alongside a live 3D preview rendered with three.js, with orbit, pan and zoom. The view updates as you edit and keeps your camera position, so you don't lose your place. Toolbar has fit, reset, wireframe and grid toggles. (Binary `.glb` files are not supported in this release.)
 - An **About** button on editor toolbars showing the product, version, and author.
 
 ## [0.3.0] - 2026-07-18

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A rich Markdown editor extension for Visual Studio Code with split preview, [[wi
 ## Features
 
 - **WYSIWYG Editing** — Edit markdown in a rich preview with contenteditable, or switch to split view or raw markdown mode.
-- **Mermaid Diagrams** — `\`\`\`mermaid` code fences render as live diagrams in the WYSIWYG/split preview. Diagrams are read-only there (edit the source in Raw/Split mode). A dedicated split-view editor opens `.mmd`/`.mermaid` files directly, with **syntax highlighting**, **error-line marking**, **zoom and pan**, and **PNG / print (Save as PDF) export** — all themed to match VS Code's light or dark theme.
+- **Mermaid Diagrams** — `\`\`\`mermaid` code fences render as live diagrams in the WYSIWYG/split preview. Diagrams are read-only there (edit the source in Raw/Split mode). A dedicated split-view editor opens `.mmd`/`.mermaid` files directly, with **syntax highlighting**, **error-line marking**, **zoom and pan**, **PNG / print (Save as PDF) export**, and **authoring help** (template gallery, snippet palette, and node-ID completions) — all themed to match VS Code's light or dark theme.
+- **3D Model Viewer** — open a `.gltf` file to get its JSON source alongside a live 3D preview rendered with three.js, with orbit, pan and zoom. The preview updates as you edit and keeps your camera position.
 - **Task Checklists** — GFM `- [ ] task` / `- [x] task` checkboxes render as clickable checkboxes in the preview and toggle directly in the markdown source. Handy for spec-driven workflows (e.g. GitHub Spec Kit `tasks.md` files).
 - **Toolbar** — Quick-access buttons for bold, italic, headings, links, images, code blocks, lists, and blockquotes.
 - **[[Wikilinks]]** — Link between markdown files using `[[filename]]` or `[[filename|display text]]` syntax (Obsidian-compatible) with autocomplete suggestions.
@@ -60,6 +61,20 @@ Diagrams follow your VS Code light or dark theme and re-render automatically whe
 ### Task Checklists
 
 `- [ ] some task` and `- [x] done task` lines render as checkboxes in the preview. Click a checkbox to toggle it — the change is written straight back to the markdown source as `[ ]`/`[x]`.
+
+### Writing Mermaid Diagrams
+
+The `.mmd` editor helps you write diagrams rather than just render them:
+
+- **Template** — inserts a working starter diagram (flowchart, sequence, class, state, ER, gantt, pie, mind map) with its first label selected to type over.
+- **Snippet palette** — the buttons beside Template change with the diagram type you're writing: node shapes and link styles for flowcharts, `participant`/`loop`/`alt` for sequence diagrams, and so on.
+- **Completions** — as you type, the editor offers the node IDs already in your diagram (press `Ctrl+Space` to summon them manually). This is the most useful one: in Mermaid a mistyped node ID doesn't produce an error, it quietly creates a stray disconnected node.
+
+### 3D Models (`.gltf`)
+
+Open a `.gltf` file and you'll get the JSON source on the left with a live 3D preview on the right. Drag to orbit, scroll to zoom, right-drag to pan. The preview updates as you edit and **keeps your camera position**, so you don't lose your place while tweaking a model. The toolbar has fit-to-view, reset, wireframe and grid toggles, plus an Update button (used automatically for files over 2 MB, where live updating is disabled).
+
+Models with external `.bin` buffers and textures work as long as those files sit within your workspace folder. Binary `.glb` files aren't supported yet, nor are Draco/KTX2-compressed assets — those report a clear error rather than failing silently.
 
 ### Comparing Versions
 


### PR DESCRIPTION
## Summary

The 1.0.0 CHANGELOG entry was written during PR #50, before PRs #51 (mermaid authoring help) and #52 (glTF 3D editor) landed — so it described neither. Releasing 1.0.0 with two major features undocumented would understate the release and leave users unaware of them.

- **CHANGELOG** — adds the mermaid authoring help (templates, snippet palette, node-ID completions) and the glTF 3D editor to the 1.0.0 entry.
- **README** — adds both to the feature list, plus usage sections covering the limits worth knowing up front: `.glb` and Draco/KTX2 are unsupported (reporting a clear error rather than failing silently), and glTF external `.bin`/textures must live inside the workspace folder.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)