### PR TITLE
release: v1.1.1 — activity bar icon fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [1.1.1] - 2026-07-22
+
+### Fixed
+
+- **Activity bar icon now matches the real logo** — the 1.1.0 icon was a hand-drawn approximation that read as a plain hollow triangle. Replaced with a silhouette traced directly from `media/icon.png`'s actual pixels (not redrawn by eye), so it's pixel-accurate to the real "A" mark, counter and base included.
+
 ## [1.1.0] - 2026-07-20
 
 ### Added

--- a/log.md
+++ b/log.md
@@ -581,3 +581,16 @@ Opened PR #55 (`feature/mmd-templates-and-activity-icon` → `develop`), then ra
 - **Select-all then choosing a template hit the "safe" fast path** — `selectionStart === 0` looked like "caret at document start" even though the entire document was selected, silently inserting at position 0 without deleting the selection (old content kept, producing an invalid two-diagram file) and no warning shown. The boundary check now also requires the selection to be collapsed; any active selection routes through the same host-confirmation modal.
 
 All fixes verified: unit tests (110/110), the existing 69 Playwright checks re-run clean, plus 10 new Playwright checks written specifically against these findings (keyboard Tab+Enter activation, select-all confirmation, stale-menu-closes-on-external-update, and all 5 repaired templates rendering error-free after typing over their placeholder).
+
+## 2026-07-22 — Activity bar icon replaced with a pixel-traced silhouette (v1.1.1)
+
+The user pointed out the 1.1.0 activity bar icon didn't actually look like `media/icon.png` — it was a hand-drawn approximation (an outer triangle with a triangular hole cut out) that read as a plain hollow triangle, not the "A" mark.
+
+Rather than redraw it by eye again, traced it directly from the source image's pixels:
+1. Read `media/icon.png` (128x128) pixel-by-pixel with `pngjs`; every pixel with alpha > 50% became solid black, everything else white — this flattens all the logo's color facets into one silhouette, exactly the way VS Code's activity-bar CSS-mask recoloring will flatten it anyway regardless of the source's colors.
+2. Traced that black/white mask into an SVG path with `potrace`, using `optCurve: false` and `alphaMax: 0` to force straight-edged polygon output (curve-fitting is wrong for a source that's entirely triangular facets).
+3. Rescaled the resulting path from the 128px source down to a 24x24 viewBox to match the existing file's convention.
+
+This makes the icon pixel-accurate to the real logo — same silhouette, same counter/hole, same base — rather than an approximation. Before committing, rendered a preview simulating VS Code's activity-bar CSS-mask recoloring at real 24px icon size (published as a Claude Artifact) so the user could confirm it looked right first.
+
+Version bumped 1.1.0 → 1.1.1 (patch — visual fix only, no behavior change).

--- a/media/activity-icon.svg
+++ b/media/activity-icon.svg
@@ -5,12 +5,13 @@
     renders), so a single solid black fill on a transparent background is
     the correct, standard approach — see VS Code's own codicon assets.
 
-    Same silhouette as the toolbar's brand/About button (src/utils.ts,
-    getBrandButtonHtml): an outer triangle with a smaller triangular
-    aperture cut out via fill-rule evenodd, forming the 'A'. The colored
-    toolbar version additionally shades one facet for a faceted look; that
-    distinction has no meaning in a flat monochrome icon, so it's omitted.
+    Traced directly from media/icon.png (the marketplace icon) rather than
+    redrawn by eye: every pixel with alpha > 50% became solid black,
+    everything else transparent, then vectorized to straight-edged paths
+    (no curve-fitting, since the source is entirely triangular facets) and
+    rescaled from the 128px source to this 24x24 viewBox. Pixel-accurate
+    to the real logo's silhouette, including its counter and base.
   -->
   <path fill="#000000" fill-rule="evenodd" clip-rule="evenodd"
-        d="M12 2.5 L22 21 L2 21 Z M12 9.6 L16.1 17.2 L7.9 17.2 Z"/>
+        d="M 11.99 2.15 L 11.86 2.07 8.58 7.46 L 5.30 12.84 2.65 17.20 L 0.01 21.56 2.98 21.56 L 5.96 21.56 10.31 14.41 L 14.66 7.25 14.76 7.00 L 14.85 6.75 13.49 4.49 L 12.12 2.23 11.99 2.15 M 14.96 11.81 L 11.98 11.81 12.41 12.53 L 12.84 13.25 15.37 17.40 L 17.90 21.56 20.87 21.56 L 23.83 21.56 23.76 21.42 L 23.68 21.28 20.81 16.55 L 17.94 11.81 14.96 11.81 M 11.91 16.69 L 8.98 16.69 9.06 16.83 L 9.14 16.97 10.49 19.17 L 11.85 21.38 12.01 21.28 L 12.17 21.18 13.43 19.07 L 14.68 16.97 14.76 16.83 L 14.83 16.69 11.91 16.69"/>
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "author": {
     "name": "Advancer Limited",

--- a/todo.md
+++ b/todo.md
@@ -218,3 +218,9 @@
 - [x] Searchable dropdown (filter input + keyboard nav + scrollable list), mirroring the existing wikilink-picker pattern in editor.js, since 22 items in a plain list would be hard to scan
 - [x] Cursor-position-aware template insertion: inserts directly at the caret when it's at the very start/end of the document; when strictly mid-document, asks the host to confirm first (native modal, since confirm() is blocked in webviews) — replaces the previous "replace the whole document" flow entirely
 - [x] Fable adversarial review on PR #55; fixed 2 template bugs (sequence alias syntax backwards; 4 templates with a placeholder on a referenced identifier that broke on edit) + 2 UI bugs (keyboard Enter/Space didn't activate a Tab-focused menu item; select-all bypassed the mid-document confirmation) + 1 latent risk (stale menu left open across an external document update) — see log.md for detail
+
+## 2026-07-22 Activity bar icon replaced with a pixel-traced silhouette (v1.1.1)
+
+- [x] The 1.1.0 icon (media/activity-icon.svg) was a hand-drawn approximation that read as a plain hollow triangle rather than an "A" — replaced with a silhouette traced directly from media/icon.png's actual pixels (alpha-thresholded to black/white, then vectorized to straight-edged paths with potrace, rescaled to the 24x24 viewBox), so it's pixel-accurate to the real logo, counter and base included
+- [x] Verified with a rendered preview simulating VS Code's activity-bar CSS-mask recoloring at real 24px size before committing, per user request
+- [x] Version bumped 1.1.0 -> 1.1.1 (patch)


### PR DESCRIPTION
## Summary
Release develop → master for v1.1.1 (patch).

- **Activity bar icon fixed** — replaced the 1.1.0 hand-drawn approximation with a silhouette traced directly from `media/icon.png`'s pixels, so it's now pixel-accurate to the real logo instead of reading as a plain hollow triangle.

Already self-reviewed and merged via PR #57 (small, low-risk visual-only change; verified with a rendered activity-bar mask-recoloring preview before commit and approved by the user). No additional review needed for this release PR per project workflow.

## Test plan
- [x] `npm run compile` clean on `develop`
- [x] 110/110 unit tests pass on `develop`
- [ ] Merge and publish v1.1.1 to VS Code Marketplace