### PR TITLE
fix: mermaid print openExternal URI + icon-only snippet palette (v1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [1.1.2] - 2026-07-22
+
+### Fixed
+
+- **Print/Save as PDF could fail with a "Get an app to open this vscode-userdata link" error** on Windows — the print HTML file's URI was passed to `openExternal()` as-is, which can carry a `vscode-userdata:` scheme rather than `file:`. Rebuilt as a proper `file:` URI before opening.
+
+### Changed
+
+- **Mermaid source-editor snippet palette is now icon buttons instead of text labels** (Box, Diamond, Participant, Loop, etc.) — the full shape/option palette now fits on one toolbar row instead of wrapping across 2-3, with the label and description available as a hover tooltip.
+
 ## [1.1.1] - 2026-07-22
 
 ### Fixed

--- a/log.md
+++ b/log.md
@@ -594,3 +594,17 @@ Rather than redraw it by eye again, traced it directly from the source image's p
 This makes the icon pixel-accurate to the real logo — same silhouette, same counter/hole, same base — rather than an approximation. Before committing, rendered a preview simulating VS Code's activity-bar CSS-mask recoloring at real 24px icon size (published as a Claude Artifact) so the user could confirm it looked right first.
 
 Version bumped 1.1.0 → 1.1.1 (patch — visual fix only, no behavior change).
+
+## 2026-07-22 — Mermaid print/openExternal fix + icon-only snippet palette (v1.1.2)
+
+Two fixes were made directly in the working tree (not through this session originally) and handed off for testing and release:
+
+**Print/Save as PDF failing on Windows.** The print flow writes the diagram's SVG to a temp HTML file under `context.globalStorageUri` and hands that URI to `vscode.env.openExternal()` to open in the system browser. `globalStorageUri` can carry a `vscode-userdata:` scheme rather than `file:` (seen on Windows) — `openExternal` passes that scheme straight to the OS shell, which has no application registered for it, producing a "Get an app to open this vscode-userdata link" prompt instead of the browser's print dialog. Fixed in `src/mermaidEditorProvider.ts` by rebuilding the URI as `vscode.Uri.file(file.fsPath)` before calling `openExternal` — `fsPath` resolves to the real filesystem path regardless of the URI's scheme, so wrapping it forces a proper `file:` URI the shell can actually open.
+
+**Snippet palette: text labels → icon buttons.** The `.mmd` editor's context-aware snippet palette (Box, Diamond, Hexagon, Participant, Loop, Alt, Par, etc. — the buttons beside Template) used text-label buttons, which wrapped across 2-3 toolbar rows once a diagram type's full snippet set was shown. Replaced with small 24×24px icon buttons (hand-authored inline SVG per snippet, sharing a `viewBox="0 0 16 16"` with `stroke="currentColor"` so they theme automatically), with the old label + description now living in the `title` tooltip and a matching `aria-label`. Verified the full palette now fits on a single row at normal editor widths.
+
+Testing found one thing needing an update, not a bug: the pre-existing `toolbox-tests.js` Playwright suite queried snippet buttons by `.textContent` to find/verify them by name (e.g. `find(b => b.textContent === 'Diamond')`) — with icon-only buttons this is now always empty, so the assertions and the "click the Diamond snippet" helper both silently failed. Updated those to read the button's `title` (`"Label — Description"`) instead, which is the whole point of the change: the label moved from the DOM text to the tooltip, not away entirely.
+
+Verification: 110 unit tests, existing 89 Playwright checks (across toolbox/fable-fix/feature/review-fix/behavior suites) re-run clean after updating the stale label-lookup assertions, plus 10 new Playwright checks specifically for the icon palette (icon-only rendering, tooltip content, one-row layout, click-to-insert still works, palette still switches per diagram type). The `openExternal` fix itself isn't Playwright-testable (host-side VS Code API, not reachable from the webview harness) — verified by code review instead: `file` is `vscode.Uri.joinPath(this.context.globalStorageUri, ...)`, and `.fsPath` resolves to the real filesystem path regardless of the source URI's scheme, so `vscode.Uri.file(file.fsPath)` is a safe, correct rebuild.
+
+Version bumped 1.1.1 → 1.1.2 (patch — one bug fix, one UI change, no breaking behavior).

--- a/media/mermaidCompletions.js
+++ b/media/mermaidCompletions.js
@@ -309,60 +309,68 @@
 
   // ============================================================
   // Snippet palette — context-aware by diagram type
+  //
+  // `icon` is inner SVG markup (no <svg> wrapper) rendered by the webview
+  // inside a shared viewBox="0 0 16 16" element that supplies
+  // fill="none" stroke="currentColor" — child shapes inherit that, so only
+  // filled glyphs (a composition diamond, a state's initial/final dot) need
+  // to set their own fill. This keeps the palette buttons small icon
+  // buttons rather than words, with the label+title as the hover tooltip,
+  // so the toolbar fits on one line instead of wrapping.
   // ============================================================
   const FLOWCHART_SNIPPETS = [
-    { label: 'Box', title: 'Rectangular node', body: '${A}[Label]' },
-    { label: 'Rounded', title: 'Rounded node', body: '${A}(Label)' },
-    { label: 'Stadium', title: 'Stadium-shaped node', body: '${A}([Label])' },
-    { label: 'Circle', title: 'Circular node', body: '${A}((Label))' },
-    { label: 'Diamond', title: 'Decision node', body: '${A}{Label}' },
-    { label: 'Hexagon', title: 'Hexagonal node', body: '${A}{{Label}}' },
-    { label: 'Database', title: 'Cylinder node', body: '${A}[(Database)]' },
-    { label: 'Arrow', title: 'Arrow link', body: ' --> ' },
-    { label: 'Open', title: 'Open link (no arrowhead)', body: ' --- ' },
-    { label: 'Dotted', title: 'Dotted link', body: ' -.-> ' },
-    { label: 'Thick', title: 'Thick link', body: ' ==> ' },
-    { label: 'Labelled', title: 'Link with a label', body: ' -->|${label}| ' },
-    { label: 'Subgraph', title: 'Grouped section', body: 'subgraph ${Name}\n    \nend\n' },
+    { label: 'Box', title: 'Rectangular node', icon: '<rect x="2" y="4" width="12" height="8"/>', body: '${A}[Label]' },
+    { label: 'Rounded', title: 'Rounded node', icon: '<rect x="2" y="4" width="12" height="8" rx="3"/>', body: '${A}(Label)' },
+    { label: 'Stadium', title: 'Stadium-shaped node', icon: '<rect x="2" y="5" width="12" height="6" rx="3"/>', body: '${A}([Label])' },
+    { label: 'Circle', title: 'Circular node', icon: '<circle cx="8" cy="8" r="6"/>', body: '${A}((Label))' },
+    { label: 'Diamond', title: 'Decision node', icon: '<path d="M8 2 L14 8 L8 14 L2 8 Z"/>', body: '${A}{Label}' },
+    { label: 'Hexagon', title: 'Hexagonal node', icon: '<path d="M4.5 3 H11.5 L14 8 L11.5 13 H4.5 L2 8 Z"/>', body: '${A}{{Label}}' },
+    { label: 'Database', title: 'Cylinder node', icon: '<path d="M2 5c0-1.1 2.7-2 6-2s6 .9 6 2v6c0 1.1-2.7 2-6 2s-6-.9-6-2V5z"/><path d="M2 5c0 1.1 2.7 2 6 2s6-.9 6-2"/>', body: '${A}[(Database)]' },
+    { label: 'Arrow', title: 'Arrow link', icon: '<line x1="1.5" y1="8" x2="12" y2="8"/><path d="M9.5 5 L13 8 L9.5 11"/>', body: ' --> ' },
+    { label: 'Open', title: 'Open link (no arrowhead)', icon: '<line x1="1.5" y1="8" x2="14.5" y2="8"/>', body: ' --- ' },
+    { label: 'Dotted', title: 'Dotted link', icon: '<line x1="1.5" y1="8" x2="12" y2="8" stroke-dasharray="2.2 2.2"/><path d="M9.5 5 L13 8 L9.5 11"/>', body: ' -.-> ' },
+    { label: 'Thick', title: 'Thick link', icon: '<line x1="1.5" y1="8" x2="11.5" y2="8" stroke-width="3"/><path d="M9 5 L13.5 8 L9 11"/>', body: ' ==> ' },
+    { label: 'Labelled', title: 'Link with a label', icon: '<rect x="4" y="2" width="6" height="4" rx="1"/><line x1="1.5" y1="10" x2="12" y2="10"/><path d="M9.5 7 L13 10 L9.5 13"/>', body: ' -->|${label}| ' },
+    { label: 'Subgraph', title: 'Grouped section', icon: '<rect x="2" y="3" width="12" height="10" rx="2" stroke-dasharray="2 2"/>', body: 'subgraph ${Name}\n    \nend\n' },
   ];
 
   const SEQUENCE_SNIPPETS = [
-    { label: 'Participant', title: 'Declare a participant', body: 'participant ${Name}\n' },
-    { label: 'Actor', title: 'Declare an actor', body: 'actor ${Name}\n' },
-    { label: 'Message', title: 'Solid arrow message', body: '${A}->>B: Message\n' },
-    { label: 'Reply', title: 'Dashed reply', body: '${B}-->>A: Reply\n' },
-    { label: 'Activate', title: 'Activation block', body: 'activate ${A}\n\ndeactivate A\n' },
-    { label: 'Note', title: 'Note over participants', body: 'Note over ${A},B: Text\n' },
-    { label: 'Loop', title: 'Loop block', body: 'loop ${Every minute}\n    \nend\n' },
-    { label: 'Alt', title: 'Alternative paths', body: 'alt ${Condition}\n    \nelse Otherwise\n    \nend\n' },
-    { label: 'Opt', title: 'Optional block', body: 'opt ${Condition}\n    \nend\n' },
-    { label: 'Par', title: 'Parallel block', body: 'par ${Branch one}\n    \nand Branch two\n    \nend\n' },
+    { label: 'Participant', title: 'Declare a participant', icon: '<rect x="3" y="2" width="10" height="4" rx="1"/><line x1="8" y1="6" x2="8" y2="14" stroke-dasharray="1.6 1.6"/>', body: 'participant ${Name}\n' },
+    { label: 'Actor', title: 'Declare an actor', icon: '<circle cx="8" cy="4" r="2"/><line x1="8" y1="6" x2="8" y2="11"/><line x1="4.5" y1="8.5" x2="11.5" y2="8.5"/><line x1="8" y1="11" x2="5" y2="14"/><line x1="8" y1="11" x2="11" y2="14"/>', body: 'actor ${Name}\n' },
+    { label: 'Message', title: 'Solid arrow message', icon: '<line x1="1.5" y1="8" x2="12" y2="8"/><path d="M9.5 5 L13 8 L9.5 11"/>', body: '${A}->>B: Message\n' },
+    { label: 'Reply', title: 'Dashed reply', icon: '<line x1="3.5" y1="8" x2="14.5" y2="8" stroke-dasharray="2.2 2.2"/><path d="M6.5 5 L3 8 L6.5 11"/>', body: '${B}-->>A: Reply\n' },
+    { label: 'Activate', title: 'Activation block', icon: '<rect x="6.5" y="2" width="3" height="12"/>', body: 'activate ${A}\n\ndeactivate A\n' },
+    { label: 'Note', title: 'Note over participants', icon: '<path d="M2 2 H10 L14 6 V14 H2 Z"/><path d="M10 2 V6 H14"/>', body: 'Note over ${A},B: Text\n' },
+    { label: 'Loop', title: 'Loop block', icon: '<path d="M12.6 6.4A5 5 0 1 0 13 9"/><path d="M13 3.4 V6.6 H9.8"/>', body: 'loop ${Every minute}\n    \nend\n' },
+    { label: 'Alt', title: 'Alternative paths', icon: '<path d="M2 8 H6 M6 8 L11 4 M6 8 L11 12 M11 4 H14 M11 12 H14"/>', body: 'alt ${Condition}\n    \nelse Otherwise\n    \nend\n' },
+    { label: 'Opt', title: 'Optional block', icon: '<rect x="5" y="3" width="9" height="10" rx="2" stroke-dasharray="2 2"/><line x1="1" y1="8" x2="5" y2="8"/>', body: 'opt ${Condition}\n    \nend\n' },
+    { label: 'Par', title: 'Parallel block', icon: '<line x1="1.5" y1="5" x2="12" y2="5"/><path d="M9.5 3 L13 5 L9.5 7"/><line x1="1.5" y1="11" x2="12" y2="11"/><path d="M9.5 9 L13 11 L9.5 13"/>', body: 'par ${Branch one}\n    \nand Branch two\n    \nend\n' },
   ];
 
   const CLASS_SNIPPETS = [
-    { label: 'Class', title: 'Class with members', body: 'class ${Name} {\n    +String field\n    +method()\n}\n' },
-    { label: 'Inherit', title: 'Inheritance', body: '${Base} <|-- Derived\n' },
-    { label: 'Compose', title: 'Composition', body: '${Whole} *-- Part\n' },
-    { label: 'Aggregate', title: 'Aggregation', body: '${Whole} o-- Part\n' },
-    { label: 'Associate', title: 'Association', body: '${A} --> B\n' },
+    { label: 'Class', title: 'Class with members', icon: '<rect x="2" y="2" width="12" height="12"/><line x1="2" y1="6" x2="14" y2="6"/><line x1="2" y1="9" x2="14" y2="9"/>', body: 'class ${Name} {\n    +String field\n    +method()\n}\n' },
+    { label: 'Inherit', title: 'Inheritance', icon: '<line x1="8" y1="14" x2="8" y2="6.5"/><path d="M8 2 L11 7 H5 Z"/>', body: '${Base} <|-- Derived\n' },
+    { label: 'Compose', title: 'Composition', icon: '<line x1="7" y1="8" x2="14" y2="8"/><path d="M2 8 L5 5.5 L8 8 L5 10.5 Z" fill="currentColor" stroke="none"/>', body: '${Whole} *-- Part\n' },
+    { label: 'Aggregate', title: 'Aggregation', icon: '<line x1="7" y1="8" x2="14" y2="8"/><path d="M2 8 L5 5.5 L8 8 L5 10.5 Z"/>', body: '${Whole} o-- Part\n' },
+    { label: 'Associate', title: 'Association', icon: '<line x1="1.5" y1="8" x2="12" y2="8"/><path d="M9.5 5 L13 8 L9.5 11"/>', body: '${A} --> B\n' },
   ];
 
   const STATE_SNIPPETS = [
-    { label: 'Start', title: 'Initial state', body: '[*] --> ${State}\n' },
-    { label: 'End', title: 'Final state', body: '${State} --> [*]\n' },
-    { label: 'Transition', title: 'Labelled transition', body: '${A} --> B: event\n' },
-    { label: 'Composite', title: 'Nested state', body: 'state ${Name} {\n    [*] --> Inner\n}\n' },
-    { label: 'Choice', title: 'Choice pseudo-state', body: 'state ${choice} <<choice>>\n' },
+    { label: 'Start', title: 'Initial state', icon: '<circle cx="3" cy="8" r="2" fill="currentColor" stroke="none"/><line x1="5.5" y1="8" x2="10" y2="8"/><path d="M8 5.5 L11 8 L8 10.5"/>', body: '[*] --> ${State}\n' },
+    { label: 'End', title: 'Final state', icon: '<line x1="1.5" y1="8" x2="7.5" y2="8"/><path d="M5.5 5.5 L8.5 8 L5.5 10.5"/><circle cx="12" cy="8" r="2.6"/><circle cx="12" cy="8" r="1" fill="currentColor" stroke="none"/>', body: '${State} --> [*]\n' },
+    { label: 'Transition', title: 'Labelled transition', icon: '<rect x="1.5" y="5.5" width="4.5" height="5" rx="1.2"/><rect x="10" y="5.5" width="4.5" height="5" rx="1.2"/><line x1="6" y1="8" x2="9.5" y2="8"/><path d="M8 6 L10 8 L8 10"/>', body: '${A} --> B: event\n' },
+    { label: 'Composite', title: 'Nested state', icon: '<rect x="1.5" y="2" width="13" height="12" rx="1.5"/><rect x="4" y="5" width="8" height="6" rx="1" stroke-dasharray="1.6 1.6"/>', body: 'state ${Name} {\n    [*] --> Inner\n}\n' },
+    { label: 'Choice', title: 'Choice pseudo-state', icon: '<path d="M8 2 L14 8 L8 14 L2 8 Z"/>', body: 'state ${choice} <<choice>>\n' },
   ];
 
   const ER_SNIPPETS = [
-    { label: 'Relation', title: 'One-to-many relationship', body: '${A} ||--o{ B : label\n' },
-    { label: 'Entity', title: 'Entity with attributes', body: '${NAME} {\n    string field\n}\n' },
+    { label: 'Relation', title: 'One-to-many relationship', icon: '<line x1="2" y1="8" x2="9" y2="8"/><path d="M9 8 L14 5 M9 8 L14 8 M9 8 L14 11"/>', body: '${A} ||--o{ B : label\n' },
+    { label: 'Entity', title: 'Entity with attributes', icon: '<rect x="2" y="2" width="12" height="12"/><line x1="2" y1="6.5" x2="14" y2="6.5"/><line x1="2" y1="10" x2="14" y2="10"/>', body: '${NAME} {\n    string field\n}\n' },
   ];
 
   const COMMON_SNIPPETS = [
-    { label: 'Comment', title: 'Comment line', body: '%% ${note}\n' },
-    { label: 'Title', title: 'Accessible title', body: 'accTitle: ${Title}\n' },
+    { label: 'Comment', title: 'Comment line', icon: '<path d="M2 3 H14 V10 H6 L3 13 V10 H2 Z"/>', body: '%% ${note}\n' },
+    { label: 'Title', title: 'Accessible title', icon: '<path d="M3 3 H13 M8 3 V13"/>', body: 'accTitle: ${Title}\n' },
   ];
 
   const SNIPPETS_BY_TYPE = {

--- a/media/mermaidEditor.css
+++ b/media/mermaidEditor.css
@@ -389,23 +389,30 @@ body.vscode-light .mmd-line.mmd-error-line {
 .mmd-snippets {
   display: flex;
   align-items: center;
-  gap: 4px;
-  /* Wrap rather than scroll: with ~15 snippets, discoverability beats
-     saving a row of vertical space. */
+  gap: 2px;
+  /* Icon buttons are narrow enough that the full palette fits one row at
+     most editor widths; wrap is kept only as a fallback for very narrow
+     panes rather than the expected layout. */
   flex-wrap: wrap;
 }
 
 .mmd-snippets button {
-  background: var(--button-bg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: transparent;
   color: var(--button-fg);
   border: none;
   border-radius: 3px;
-  padding: 3px 8px;
+  padding: 0;
   cursor: pointer;
-  font-family: var(--preview-font-family);
-  font-size: 11px;
-  line-height: 1.4;
-  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.mmd-snippets button svg {
+  display: block;
 }
 
 .mmd-snippets button:hover {

--- a/media/mermaidEditor.js
+++ b/media/mermaidEditor.js
@@ -823,8 +823,17 @@
     snippetsBar.textContent = '';
     for (const snippet of completions.getSnippets(textarea.value)) {
       const btn = document.createElement('button');
-      btn.textContent = snippet.label;
-      btn.title = snippet.title;
+      btn.className = 'mmd-snippet-btn';
+      // Icon-only button: the label/title pair becomes the hover tooltip
+      // (and the accessible name) instead of visible words, so a full
+      // shape/option palette fits on one toolbar row.
+      btn.innerHTML =
+        '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" ' +
+        'stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">' +
+        snippet.icon +
+        '</svg>';
+      btn.title = `${snippet.label} — ${snippet.title}`;
+      btn.setAttribute('aria-label', `${snippet.label}: ${snippet.title}`);
       btn.addEventListener('click', () => insertSnippet(snippet.body));
       snippetsBar.appendChild(btn);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "author": {
     "name": "Advancer Limited",

--- a/src/mermaidEditorProvider.ts
+++ b/src/mermaidEditorProvider.ts
@@ -281,7 +281,12 @@ export class MermaidEditorProvider implements vscode.CustomTextEditorProvider {
                 file,
                 Buffer.from(buildPrintHtml(path.basename(document.fileName), message.svg), 'utf8')
               );
-              await vscode.env.openExternal(file);
+              // globalStorageUri can be a vscode-userdata: URI rather than
+              // file: (seen on Windows) — openExternal then hands that
+              // scheme straight to the OS shell, which has no app
+              // registered for it. Uri.file(fsPath) rebuilds a real file:
+              // URI the shell/browser can open.
+              await vscode.env.openExternal(vscode.Uri.file(file.fsPath));
             } catch (err) {
               vscode.window.showErrorMessage(
                 `Failed to open the diagram for printing: ${err instanceof Error ? err.message : String(err)}`

--- a/todo.md
+++ b/todo.md
@@ -224,3 +224,11 @@
 - [x] The 1.1.0 icon (media/activity-icon.svg) was a hand-drawn approximation that read as a plain hollow triangle rather than an "A" — replaced with a silhouette traced directly from media/icon.png's actual pixels (alpha-thresholded to black/white, then vectorized to straight-edged paths with potrace, rescaled to the 24x24 viewBox), so it's pixel-accurate to the real logo, counter and base included
 - [x] Verified with a rendered preview simulating VS Code's activity-bar CSS-mask recoloring at real 24px size before committing, per user request
 - [x] Version bumped 1.1.0 -> 1.1.1 (patch)
+
+## 2026-07-22 Mermaid print/openExternal fix + icon-only snippet palette (v1.1.2)
+
+- [x] Print/Save as PDF could fail with a "Get an app to open this vscode-userdata link" error on Windows — the print HTML file's URI could carry a `vscode-userdata:` scheme (from `context.globalStorageUri`) rather than `file:`; fixed by rebuilding via `vscode.Uri.file(file.fsPath)` before `openExternal()`
+- [x] Snippet palette (Box, Diamond, Participant, Loop, etc.) changed from text-label buttons to 24x24px icon buttons with title/aria-label tooltips, so the full palette fits on one toolbar row instead of wrapping across 2-3
+- [x] Verified with Playwright: icon-only rendering, tooltip carries label+description, layout fits one row, click-to-insert still works, palette still switches per diagram type — plus updated the pre-existing toolbox-tests.js snippet-palette assertions, which read button textContent (now empty, since buttons are icon-only) rather than the title tooltip
+- [x] Full regression: 110 unit tests + 89 Playwright checks (25 toolbox + 10 fable-fix + 23 feature + 7 review-fix + 14 behavior + 10 new icon-palette), all green
+- [x] Version bumped 1.1.1 -> 1.1.2 (patch)


### PR DESCRIPTION
## Summary
- **Print/Save as PDF fix**: `openExternal()` could receive a `vscode-userdata:` URI instead of `file:` (seen on Windows, since the print HTML lives under `context.globalStorageUri`), causing "Get an app to open this vscode-userdata link" instead of opening the browser print dialog. Fixed by rebuilding via `vscode.Uri.file(file.fsPath)`.
- **Snippet palette → icon buttons**: replaced text-label snippet buttons (Box, Diamond, Participant, Loop, etc.) with 24x24px icon buttons + title/aria-label tooltips, so the full palette fits on one toolbar row instead of wrapping across 2-3.
- Version bumped 1.1.1 → 1.1.2 (patch).

## Test plan
- [x] `npm run compile` clean
- [x] 110/110 unit tests pass
- [x] 89/89 Playwright checks pass, including 10 new checks for the icon palette (icon-only rendering, tooltip content = old label+description, single-row layout, click-to-insert unchanged, palette still switches per diagram type)
- [x] Updated the pre-existing `toolbox-tests.js` snippet-palette assertions, which looked up buttons by `textContent` (now empty on icon-only buttons) — switched to reading the `title` tooltip instead
- [ ] The `openExternal` fix itself isn't Playwright-testable (host-side VS Code API); verified by code review — `file.fsPath` resolves correctly regardless of the source URI's scheme, so wrapping it in `vscode.Uri.file()` is a safe, correct rebuild