### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [1.3.1] - 2026-07-26
+
+### Fixed
+
+- **Sidebar Markdown file list no longer shows files more than once.** The list still carried an old link-navigation feature: each file row could expand to show the files it links to and from, so files already in the list reappeared as sub-rows under other files, reading as duplicates. Link exploration lives in the interactive graph (the Show Graph button), so the list is now just files — every file exactly once.
+- **Sidebar flat view is now strictly alphabetical** — the same files as folder view, flattened. Previously the active file was hoisted to the top of the list; it keeps its highlight but stays in alphabetical position.
+
 ## [1.3.0] - 2026-07-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "author": {
     "name": "Advancer Limited",


### PR DESCRIPTION
## Summary

Version bump 1.3.0 → 1.3.1 (patch) + CHANGELOG entry for the sidebar file-list fix merged in #65:

- Sidebar Markdown file list no longer shows files more than once (link-navigation sub-rows removed; link exploration lives in Show Graph)
- Flat view is strictly alphabetical (active file keeps its highlight, no longer hoisted to the top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)