### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [1.3.1] - 2026-07-26
+
+### Fixed
+
+- **Sidebar Markdown file list no longer shows files more than once.** The list still carried an old link-navigation feature: each file row could expand to show the files it links to and from, so files already in the list reappeared as sub-rows under other files, reading as duplicates. Link exploration lives in the interactive graph (the Show Graph button), so the list is now just files — every file exactly once.
+- **Sidebar flat view is now strictly alphabetical** — the same files as folder view, flattened. Previously the active file was hoisted to the top of the list; it keeps its highlight but stays in alphabetical position.
+
 ## [1.3.0] - 2026-07-23
 
 ### Added

--- a/log.md
+++ b/log.md
@@ -672,3 +672,13 @@ A Fable adversarial review of PR #63 found a genuine "ships broken" bug in the h
 **NIT — `getFolder()`'s full-path change has an unadvertised ripple effect.** Since the sidebar's flat view no longer displays `node.folder` at all (per the user's steer earlier this session), the full-vs-immediate-parent question was almost moot for THAT purpose — but `getFolder()` is also used by the full-graph panel's node coloring/tooltips and by sidebar search matching, both of which silently got more granular (folder colors now cluster by full path instead of just the leaf folder name; searching now also matches ancestor folder names). Not a regression — arguably an improvement — but wasn't called out. Added a CHANGELOG line and corrected two stale doc comments that still said "immediate parent"/"parent folder name" instead of "full folder path".
 
 Verification after all fixes: 117 unit tests (7 new), 56 Playwright checks (31 sidebar-tabs + 9 sidebar-fable-fix + 16 editor-toolbar) all re-run clean, `check-types`/compile clean.
+
+## 2026-07-26 — Sidebar flat list: files only, alphabetical (no link sub-rows)
+
+User re-reported "the same file shown multiple times" in the sidebar's flat Markdown view and asked that the list be exactly the folder view's files, flattened alphabetically. Root cause of the perceived duplication: the list still carried the old link-navigation feature — every file row computed its incoming/outgoing wikilinks (`sendFileList` in `graphViewProvider.ts`) and rendered them as expandable sub-rows in the webview, so files already present in the list reappeared as link children under other files (expand state persisted across re-renders via `expandedNodes`). Separately, the flat sort hoisted the active file to the top, so the list wasn't purely alphabetical either. Link navigation now lives in the interactive graph (Show Graph), so the feature was removed rather than patched:
+
+- `src/graph/graphViewProvider.ts` — `SidebarFileNode` dropped its `links` field; `sendFileList()` no longer computes outgoing links/backlinks per file; sort is plain `label.localeCompare` (active file keeps its highlight but is no longer pinned first).
+- `media/graph.js` — removed `expandedNodes`, the ▶/▼ toggle, the link-count badge, the expanded link sub-list rendering, and the `node-toggle`/`link-item` click handling; a file row is now just icon + label, identical in shape to the Mermaid tab's rows.
+- `media/graph.css` — removed the now-dead `.node-toggle`, `.node-badge`, and `.link-*` rules.
+
+No committed tests referenced the removed UI (verified by grep). Verification: `npm run check-types` clean, `npm run compile` clean, 117 unit tests pass.

--- a/media/graph.css
+++ b/media/graph.css
@@ -181,18 +181,6 @@ html, body {
   color: var(--vscode-list-activeSelectionForeground, #fff);
 }
 
-.node-toggle {
-  flex-shrink: 0;
-  width: 14px;
-  text-align: center;
-  font-size: 9px;
-  color: var(--vscode-descriptionForeground, #888);
-}
-
-.node-toggle.expanded {
-  color: var(--vscode-editor-foreground, #d4d4d4);
-}
-
 .node-icon {
   flex-shrink: 0;
   font-size: 12px;
@@ -205,63 +193,6 @@ html, body {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 12px;
-}
-
-.node-badge {
-  flex-shrink: 0;
-  background: var(--vscode-badge-background, #4d4d4d);
-  color: var(--vscode-badge-foreground, #ccc);
-  border-radius: 8px;
-  padding: 0 5px;
-  font-size: 10px;
-  line-height: 16px;
-  min-width: 16px;
-  text-align: center;
-}
-
-.file-node.active .node-badge {
-  background: rgba(255, 255, 255, 0.2);
-}
-
-/* Links sub-list */
-.link-list {
-  padding-left: 28px;
-  margin-bottom: 2px;
-}
-
-.link-item {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 2px 8px;
-  cursor: pointer;
-  font-size: 11px;
-  border-radius: 3px;
-}
-
-.link-item:hover {
-  background: var(--vscode-list-hoverBackground, #2a2d2e);
-}
-
-.link-arrow {
-  flex-shrink: 0;
-  width: 14px;
-  text-align: center;
-  font-size: 11px;
-}
-
-.link-in {
-  color: #4ec9b0;
-}
-
-.link-out {
-  color: #4a9eff;
-}
-
-.link-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* ================================================

--- a/media/graph.js
+++ b/media/graph.js
@@ -12,10 +12,6 @@
   const mermaidSearchInput = /** @type {HTMLInputElement} */ (document.getElementById('mermaid-search-input'));
   const btnToggleMermaidView = document.getElementById('btn-toggle-mermaid-view');
 
-  // Track which nodes are expanded (Markdown Links tab only — its backlink
-  // sub-lists are the one thing that still needs per-node expand state).
-  const expandedNodes = new Set();
-
   // ================================================
   // Persisted per-tab state (view mode survives a webview reload)
   // ================================================
@@ -221,19 +217,10 @@
     const fragment = document.createDocumentFragment();
 
     renderGrouped(fragment, nodes, effectiveMode, (frag, node, depth) => {
-      const hasLinks = node.links && node.links.length > 0;
-      const isExpanded = expandedNodes.has(node.relativePath);
-
       const row = document.createElement('div');
       row.className = 'file-node' + (node.isActive ? ' active' : '');
       row.dataset.path = node.relativePath;
       row.style.paddingLeft = (8 + depth * 14) + 'px';
-
-      const toggle = document.createElement('span');
-      toggle.className = 'node-toggle' + (isExpanded ? ' expanded' : '');
-      toggle.textContent = hasLinks ? (isExpanded ? '▼' : '▶') : '•';
-      toggle.style.cursor = hasLinks ? 'pointer' : 'default';
-      row.appendChild(toggle);
 
       const icon = document.createElement('span');
       icon.className = 'node-icon';
@@ -245,48 +232,12 @@
       label.textContent = node.label;
       row.appendChild(label);
 
-      if (hasLinks) {
-        const badge = document.createElement('span');
-        badge.className = 'node-badge';
-        badge.textContent = String(node.links.length);
-        row.appendChild(badge);
-      }
-
       // Flat view is deliberately just an alphabetical file list, no folder
       // info — folder view (the tree itself) is where that context lives.
-      // Two files sharing a name and immediate folder in different parent
-      // projects would otherwise look like duplicates even with a folder
-      // tag (it only ever showed the immediate parent, e.g. both would say
-      // "docs"); flat view not claiming to disambiguate at all is clearer
-      // than a half-disambiguating tag.
+      // Link navigation lives in the interactive graph (Show Graph button),
+      // not here — files appear exactly once, same set as folder view.
 
       frag.appendChild(row);
-
-      if (hasLinks && isExpanded) {
-        const linkList = document.createElement('div');
-        linkList.className = 'link-list';
-        linkList.style.paddingLeft = (28 + depth * 14) + 'px';
-
-        for (const link of node.links) {
-          const linkRow = document.createElement('div');
-          linkRow.className = 'link-item';
-          linkRow.dataset.path = link.relativePath;
-
-          const arrow = document.createElement('span');
-          arrow.className = 'link-arrow ' + (link.direction === 'in' ? 'link-in' : 'link-out');
-          arrow.innerHTML = link.direction === 'in' ? '&#8592;' : '&#8594;';
-          linkRow.appendChild(arrow);
-
-          const linkLabel = document.createElement('span');
-          linkLabel.className = 'link-label';
-          linkLabel.textContent = link.label;
-          linkRow.appendChild(linkLabel);
-
-          linkList.appendChild(linkRow);
-        }
-
-        frag.appendChild(linkList);
-      }
     });
 
     fileList.innerHTML = '';
@@ -439,32 +390,9 @@
 
   fileList?.addEventListener('click', (e) => {
     const target = /** @type {HTMLElement} */ (e.target);
-
-    const toggle = target.closest('.node-toggle');
-    if (toggle) {
-      const row = toggle.closest('.file-node');
-      if (row) {
-        const path = row.dataset.path;
-        if (expandedNodes.has(path)) {
-          expandedNodes.delete(path);
-        } else {
-          expandedNodes.add(path);
-        }
-        renderFileList(lastLinksNodes);
-      }
-      return;
-    }
-
     const fileNode = target.closest('.file-node');
-    if (fileNode && !target.closest('.node-toggle')) {
+    if (fileNode) {
       vscode.postMessage({ type: 'openFile', relativePath: fileNode.dataset.path });
-      return;
-    }
-
-    const linkItem = target.closest('.link-item');
-    if (linkItem) {
-      vscode.postMessage({ type: 'openFile', relativePath: linkItem.dataset.path });
-      return;
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "author": {
     "name": "Advancer Limited",

--- a/src/graph/graphViewProvider.ts
+++ b/src/graph/graphViewProvider.ts
@@ -20,7 +20,6 @@ interface SidebarFileNode {
   relativePath: string;
   label: string;
   folder: string;
-  links: Array<{ relativePath: string; label: string; direction: 'in' | 'out' }>;
   isActive: boolean;
 }
 
@@ -271,51 +270,17 @@ export class GraphViewProvider implements vscode.WebviewViewProvider {
         }
       }
 
-      const links: SidebarFileNode['links'] = [];
-
-      // Outgoing links
-      for (const link of file.outgoingLinks) {
-        const resolved = this.fileIndexService.resolveWikilink(link.target);
-        if (resolved) {
-          const target = this.fileIndexService.getFileEntry(resolved);
-          if (target) {
-            links.push({
-              relativePath: resolved,
-              label: target.stem,
-              direction: 'out',
-            });
-          }
-        }
-      }
-
-      // Incoming links (backlinks)
-      const backlinks = this.fileIndexService.getBacklinksFor(file.stem);
-      for (const bl of backlinks) {
-        // Avoid duplicates (if A links to B and B links to A)
-        if (!links.some(l => l.relativePath === bl.relativePath)) {
-          links.push({
-            relativePath: bl.relativePath,
-            label: bl.stem,
-            direction: 'in',
-          });
-        }
-      }
-
       nodes.push({
         relativePath: file.relativePath,
         label: file.stem,
         folder: file.folder,
-        links,
         isActive: file.relativePath === activePath,
       });
     }
 
-    // Sort: active file first, then alphabetically
-    nodes.sort((a, b) => {
-      if (a.isActive && !b.isActive) return -1;
-      if (!a.isActive && b.isActive) return 1;
-      return a.label.localeCompare(b.label);
-    });
+    // Plain alphabetical order — the same files as folder view, flattened.
+    // The active file keeps its highlight but is not hoisted to the top.
+    nodes.sort((a, b) => a.label.localeCompare(b.label));
 
     this.view.webview.postMessage({
       type: 'fileList',

--- a/todo.md
+++ b/todo.md
@@ -255,3 +255,12 @@
 - [x] Converted 8 Markdown toolbar buttons (Link, Image, Code, Code Block, Unordered/Ordered List, Blockquote, Horizontal Rule) plus the new Print button from text labels to icons with tooltips — left Bold/Italic/Strikethrough and headings as text (already compact, and a generic heading icon can't convey which level), left Grammar as text (its label communicates "Checking..." progress mid-request, which an icon-only button would lose), left the Edit/Split/Raw view toggle as text (mode names, not standard recognizable icon actions)
 - [x] Verified with a new Playwright harness for the main Markdown editor webview (previously untested) — 16 checks covering icon rendering, that formatting actions still work after the HTML restructure, and the Print button posting the live preview's actual rendered HTML — plus updated the existing sidebar test harness (which had gone stale relative to the tab rename/icons, so it was silently not exercising them) with 5 new checks, for 56 total Playwright checks across both webviews, all green
 - [x] Version bumped 1.2.0 -> 1.3.0 (minor: new Print feature, alongside fixes and UI polish)
+
+## 2026-07-26 Sidebar flat list simplification (fix/sidebar-file-list-simplify)
+
+- [x] Remove link-navigation sub-rows from the sidebar Markdown file list (expandable in/out wikilink rows made files appear multiple times; link navigation now lives in the Show Graph panel)
+- [x] Flat view sorts purely alphabetically (active file no longer hoisted to the top; still highlighted)
+- [x] Drop `links` from `SidebarFileNode` + backlink/outgoing-link computation in `sendFileList()`
+- [x] Remove dead expand/badge/link CSS and click handlers from `media/graph.js` / `media/graph.css`
+- [x] Verify: check-types + compile clean, 117 unit tests pass
+- [ ] PR fix/sidebar-file-list-simplify → develop, self-review, hand off merge


### PR DESCRIPTION
## Release 1.3.1

### Fixed
- Sidebar Markdown file list no longer shows files more than once — the old link-navigation sub-rows (expandable in/out wikilink rows under each file) are removed; link exploration lives in the interactive graph (Show Graph button). The list is now exactly the folder view's files, flattened. (#65)
- Sidebar flat view is strictly alphabetical — the active file keeps its highlight but is no longer hoisted to the top. (#65)

### Chore
- Version bump 1.3.0 → 1.3.1 + CHANGELOG. (#66)

Verified: check-types + compile clean, 117 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)