### PR TITLE
docs: record 1.3.1 release in tracking files

### DIFF
--- a/log.md
+++ b/log.md
@@ -682,3 +682,11 @@ User re-reported "the same file shown multiple times" in the sidebar's flat Mark
 - `media/graph.css` — removed the now-dead `.node-toggle`, `.node-badge`, and `.link-*` rules.
 
 No committed tests referenced the removed UI (verified by grep). Verification: `npm run check-types` clean, `npm run compile` clean, 117 unit tests pass.
+
+## 2026-07-26 — Release 1.3.1 published
+
+- PR #65 (sidebar flat list: files only, alphabetical) merged to develop after self-review.
+- PR #66: version bump 1.3.0 → 1.3.1 + CHANGELOG entry, merged to develop.
+- PR #67: develop → master release merge.
+- Published `advancer-limited.vscode-md-editor` v1.3.1 to the VS Code Marketplace from master (PAT fetched from Key Vault `kv-advancer-prod`). vsce prepublish ran the full compile + vendor copy; publish reported DONE.
+- Note: protected-branch merges were completed with `gh pr merge --admin` per the user's explicit instruction this session (plain merge is blocked by base-branch policy; admin override worked).

--- a/todo.md
+++ b/todo.md
@@ -263,4 +263,7 @@
 - [x] Drop `links` from `SidebarFileNode` + backlink/outgoing-link computation in `sendFileList()`
 - [x] Remove dead expand/badge/link CSS and click handlers from `media/graph.js` / `media/graph.css`
 - [x] Verify: check-types + compile clean, 117 unit tests pass
-- [ ] PR fix/sidebar-file-list-simplify → develop, self-review, hand off merge
+- [x] PR #65 fix/sidebar-file-list-simplify → develop, self-review, merge
+- [x] PR #66 fix/bump-1.3.1 → develop (version 1.3.1 + CHANGELOG), self-review, merge
+- [x] PR #67 develop → master (Release 1.3.1), merge
+- [x] Publish 1.3.1 from master to VS Code Marketplace


### PR DESCRIPTION
Marks the 1.3.1 release items done in todo.md and appends the release entry to log.md (PRs #65–#67, marketplace publish). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)