### PR TITLE
chore: fix vendor-bundle line-ending noise + ignore personal .vscode settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Vendored/generated bundles (rewritten by scripts/copy-vendor.js and esbuild
+# on every compile) — disable line-ending conversion so they don't show as
+# perpetually "modified" on Windows after each build.
+media/force-graph.min.js -text
+media/markdown-it.min.js -text
+media/mermaid.min.js -text
+media/three-bundle.js -text
+media/turndown.browser.umd.js -text

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 *.vsix
 .vscode-test/
 
+# Personal editor settings (Peacock colors etc.)
+.vscode/settings.json
+
 # Claude Code
 .claude/
 


### PR DESCRIPTION
## Summary

Cleans up two sources of permanent working-tree noise on Windows:

- **.gitattributes (new)** — the five vendored/generated bundles in `media/` (`force-graph.min.js`, `markdown-it.min.js`, `mermaid.min.js`, `three-bundle.js`, `turndown.browser.umd.js`) are rewritten with LF endings by `scripts/copy-vendor.js`/esbuild on every `npm run compile`, so autocrlf flagged them as modified even though `git diff` was byte-for-byte empty. Marked `-text` (no eol conversion) — hand-authored `media/*.js` files are deliberately not affected.
- **.gitignore** — ignore `.vscode/settings.json` (personal Peacock window-color settings, not project config).

## Verification

- After adding the attributes and re-checking out the bundles, `git status` is clean
- Ran `npm run compile` (which re-runs copy-vendor) — bundles stay clean
- `.vscode/settings.json` no longer appears as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)