### PR TITLE
chore: bump version to 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [1.3.2] - 2026-07-26
+
+### Fixed
+
+- **Nested copies of your repository are no longer indexed** — this was the real cause of the same file appearing many times in the sidebar. Tools that create a full working copy inside your project (notably the per-agent git worktrees Claude Code writes to `.claude/worktrees/`) meant every document was indexed once per copy: in one real workspace, 35 markdown files became 502 entries. It could also make a `[[wikilink]]` resolve to a copy inside a worktree instead of the real file.
+
+### Added
+
+- **New `vscodeMdEditor.exclude` setting** — glob patterns the Markdown and Mermaid file lists (and the link graph) should ignore. Defaults to `**/node_modules/**`, `**/.git/**` and `**/.claude/worktrees/**`. Your existing `files.exclude` and `search.exclude` settings are now honoured on top of these, so anything hidden from the Explorer or search is hidden here too.
+- **Flat view tells same-named files apart** — a file whose name is shared by another file (the several `README.md` most repos have) now shows its folder path in dimmed text. Files with a unique name stay as a plain name, as before.
+
 ## [1.3.1] - 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "author": {
     "name": "Advancer Limited",


### PR DESCRIPTION
Version bump 1.3.1 → 1.3.2 (patch) + CHANGELOG for the nested-repo-copy indexing fix in #70:

- Nested copies of the repository (Claude Code's `.claude/worktrees/`) are no longer indexed — the real cause of duplicate sidebar entries (35 files → 502 in one workspace)
- New `vscodeMdEditor.exclude` setting; `files.exclude` / `search.exclude` now honoured
- Flat view disambiguates same-named files with a dimmed folder path

🤖 Generated with [Claude Code](https://claude.com/claude-code)