### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the VS Code MD Editor extension will be documented in this file.
 
+## [1.4.0] - 2026-07-26
+
+### Fixed
+
+- **New files now appear in the sidebar straight away.** Adding a `.md` or `.mmd` file outside VS Code — from a terminal, a `git checkout` or branch switch, or a script — didn't show up until you reloaded the window. The file lists only listened for file operations VS Code itself performed, so anything created by another program went unnoticed. They now watch the filesystem directly, and deletions are picked up the same way.
+- **A file created by another program is re-read once its content is written**, so its `[[wikilinks]]` are picked up. Previously an externally created file could be indexed while still empty, leaving it out of backlinks and the graph. Content changed entirely outside VS Code (a `git checkout` rewriting files, for instance) is now noticed too.
+
+### Added
+
+- **Refresh button on both sidebar tabs** — forces a rescan. Normally unnecessary now that new files are detected automatically, but file watching legitimately misses things: paths under `files.watcherExclude`, network and remote filesystems, and very large trees that exhaust the OS watcher limit. The icon spins briefly so you can tell the rescan ran even when nothing changed.
+
 ## [1.3.2] - 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-md-editor",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-md-editor",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-md-editor",
   "displayName": "VS Code MD Editor",
   "description": "A rich Markdown editor with live preview, Mermaid diagrams, task checklists, wikilinks, graph visualizer, version diff, and LanguageTool grammar checking",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "license": "MIT",
   "author": {
     "name": "Advancer Limited",


### PR DESCRIPTION
Version bump 1.3.2 → 1.4.0 (minor — new Refresh button) + CHANGELOG for #74:

- New `.md`/`.mmd` files created outside VS Code now appear without a reload
- Externally created files are re-read once their content lands, so wikilinks are parsed
- Refresh button on both sidebar tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)