### PR TITLE
docs: record 1.4.0 release in tracking files

### DIFF
--- a/log.md
+++ b/log.md
@@ -728,3 +728,10 @@ User report: adding a `.mmd` file (and, on follow-up, a `.md` file) didn't show 
 **Verification.** `check-types`/compile clean, 128 unit tests green. Ran `media/graph.js` against a DOM shim to confirm both buttons render their icon, attach a click handler, add and then clear the `spinning` class, and post `{type:'refresh', kind:'markdown'|'mermaid'}` with the right kind.
 
 **Self-review follow-up (PR #74).** The new `onDidCreate` handler indexes a file the moment it appears on disk — but a program that creates a file and *then* writes it (a script, a `git checkout`) would leave us having read an empty body. The file would show up in the sidebar (the reported symptom fixed) while its `[[wikilinks]]` silently went unparsed, contributing nothing to backlinks or the graph until something re-saved it. Added `watcher.onDidChange`, which skips documents currently open in the editor (`workspace.textDocuments`) because the existing save/text-change handlers already cover those with the in-memory text — without that skip, every in-editor save would index twice and re-render the sidebar twice. As a side benefit it also picks up content changed entirely outside VS Code, which previously went unnoticed until a reload. The Mermaid index needs no equivalent: it tracks filenames only, never content.
+
+## 2026-07-26 — Release 1.4.0 published
+
+- PR #74 (filesystem watchers + Refresh button) merged to develop after self-review; the review found and fixed a real gap of its own (an externally created file could be indexed before its content was written, so its wikilinks went unparsed — `watcher.onDidChange` now covers that, skipping documents open in the editor so in-editor saves don't index twice).
+- PR #75: version bump 1.3.2 → 1.4.0 (minor — the Refresh button is a new user-facing control) + CHANGELOG.
+- PR #76: develop → master release merge.
+- Published `advancer-limited.vscode-md-editor` v1.4.0 to the VS Code Marketplace from master.

--- a/todo.md
+++ b/todo.md
@@ -289,4 +289,7 @@
 - [x] Made `refresh()` public on both services; new `refresh` sidebar message
 - [x] Refresh button on both tabs (icon-only, 600ms spin for feedback, disabled under prefers-reduced-motion) as the escape hatch for what file watching can legitimately miss
 - [x] Verified: check-types/compile clean, 128 tests green, DOM-shim check of both buttons (icon, handler, spin lifecycle, message payload)
-- [ ] PR feature/auto-refresh-file-lists → develop, self-review, merge
+- [x] PR #74 feature/auto-refresh-file-lists → develop, self-review (found + fixed the empty-content-on-external-create gap), merge
+- [x] PR #75 fix/bump-1.4.0 → develop (version 1.4.0 + CHANGELOG), self-review, merge
+- [x] PR #76 develop → master (Release 1.4.0), merge
+- [x] Publish 1.4.0 from master to VS Code Marketplace


### PR DESCRIPTION
Marks the 1.4.0 release items done in todo.md and appends the release entry to log.md (PRs #74–#76, marketplace publish). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)