### PR TITLE
docs: add LSP-first code search guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,27 @@
 - The extension uses a `CustomTextEditorProvider` for `.md` files with a webview (textarea + markdown-it preview).
 - Webview communication uses typed message protocol defined in `src/types.ts`.
 
+## Code Search: LSP first for symbols
+
+The `LSP` tool is **deferred** — load it with `ToolSearch` for `LSP` at the **first symbol lookup of the session**, not eventually. The failure mode is drift, not disagreement: grep is already in context, so it stays the path of least resistance for the whole session unless LSP is loaded early.
+
+**Use LSP when the question is about a symbol** — a function, type, class, method or interface:
+
+- "where is this defined" → `goToDefinition`
+- "who actually calls this" → `findReferences` / `incomingCalls`
+- "what implements this interface" → `goToImplementation`
+- "what's in this file" / "where does X live" → `documentSymbol` / `workspaceSymbol`
+- "what type is this" → `hover`
+
+**Keep grep for text-shaped searches**: prose, comments, docs, config values, log output, markdown, and deliberately-greppable lists you want to read as plain text.
+
+Grep doesn't understand the symbol graph. It misses call sites that indirection creates (implicit interface implementations, inherited members, re-exports) and returns noise from strings and comments that happen to share a name. One `workspaceSymbol` call typically replaces several greps plus the follow-up reads needed to work out which hits were real. Grep is not obsolete — it's the right tool for plain text. This is a per-task judgment, not a blanket swap.
+
+### What LSP covers in this repo
+
+- **`src/**/*.ts` and `media/**/*.js`** — both, via the `typescript-lsp` plugin. The webview scripts get full symbol support, not just the extension host, and `findReferences` resolves across files workspace-wide.
+- **`media/*.css` and `*.json` have no language server** (none exists in the official plugin marketplace), so selectors and config keys are grep-only by necessity.
+- **`src/` ↔ `media/` communicate through `postMessage` string literals** (`'refresh'`, `'fileList'`) — a union type on the host side, plain strings in the webview. No symbol tool spans that boundary: use LSP for the host half and grep for the webview half.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

Adds a **Code Search: LSP first for symbols** section to `CLAUDE.md` so the guidance is always applied, rather than living only in session memory.

- Use `LSP` for symbol questions — `goToDefinition`, `findReferences`/`incomingCalls`, `goToImplementation`, `documentSymbol`/`workspaceSymbol`, `hover`
- Load the deferred `LSP` tool at the *first* symbol lookup of a session, not eventually — grep is already in context, so it otherwise stays the default for the whole session by inertia
- Keep grep for text-shaped searches: prose, comments, docs, config values, markdown

## Repo-specific coverage (verified, not assumed)

- `typescript-lsp` covers **both** `src/**/*.ts` and `media/**/*.js` — confirmed with `documentSymbol` on `globMatch.ts` and `graph.js`, and `findReferences` on `matchesAnyGlob` returning 5 hits across 3 files (so it's workspace-indexed, not single-file mode)
- **No CSS or JSON language server** exists in the official plugin marketplace — `media/*.css` and `package.json` are grep-only by necessity
- `src/` ↔ `media/` couple through `postMessage` string literals, which are a union type on the host side but plain strings in the webview — no symbol tool spans that boundary

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)